### PR TITLE
fix: use fallback url if the provided url is invalid

### DIFF
--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -32,8 +32,6 @@ from typing import List
 from typing import Optional
 from typing import Set
 from urllib.parse import urlsplit
-from urllib.request import urlopen
-from urllib.error import HTTPError
 
 from autopep8 import fix_code
 from jinja2 import Environment
@@ -1058,21 +1056,15 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
         Compose the container command arguments for a generic component, taking into
         account whether the container will run in a CRI-O environment.
         """
-        elyra_github_org = os.getenv("ELYRA_GITHUB_ORG", "elyra-ai")
+
+        # NOTE: The default organization and default branch are meant for the opendatahub-io/Data-science-pipelines v2 use case 
+        # and should not be opened as PR against upstream Elyra
+        elyra_github_org = os.getenv("ELYRA_GITHUB_ORG", "opendatahub-io")
         elyra_github_branch = os.getenv("ELYRA_GITHUB_BRANCH", "dspv2" if "dev" in __version__ else __version__)
         elyra_bootstrap_script_url = os.getenv(
             "ELYRA_BOOTSTRAP_SCRIPT_URL",
             f"https://raw.githubusercontent.com/{elyra_github_org}/elyra/{elyra_github_branch}/elyra/kfp/bootstrapper.py",  # noqa E501
         )
-
-        if not elyra_bootstrap_script_url.startswith("file://"):
-            try:
-                urlopen(elyra_bootstrap_script_url)
-            except HTTPError as e:
-                self.log.debug(f"Error: HTTP {e.code} - {e.reason}")
-                if e.code == 404:
-                    # Fallback bootstrapper URL
-                    elyra_bootstrap_script_url = f"https://raw.githubusercontent.com/opendatahub-io/elyra/{elyra_github_branch}/elyra/kfp/bootstrapper.py"
 
         elyra_requirements_url = os.getenv(
             "ELYRA_REQUIREMENTS_URL",


### PR DESCRIPTION
Use fallback url for `bootstrapper.py` if an invalid URL is provided.