### PR TITLE
fix: allow kubeflow api endpoint to have scheme as optional

### DIFF
--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -114,7 +114,7 @@
           "title": "Cloud Object Storage Endpoint",
           "description": "The Cloud Object Storage endpoint",
           "type": "string",
-          "format": "uri",
+          "pattern": "^((?:https?:\\/\\/)?[^./]+(?:\\.[^./]+)+(?:\\/.*)?)$",
           "uihints": {
             "category": "Cloud Object Storage",
             "ui:placeholder": "https://your-cos-service:port"

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -47,7 +47,7 @@
           "title": "Kubeflow Pipelines API Endpoint",
           "description": "The Kubeflow Pipelines API endpoint",
           "type": "string",
-          "pattern": "(?:(?:http|https)://)?(www\\.)?[a-zA-Z0-9@:%._\\+~#?&//=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%._\\+~#?&//=]*)",
+          "pattern": "^((?:https?:\\/\\/)?[^./]+(?:\\.[^./]+)+(?:\\/.*)?)$",
           "uihints": {
             "category": "Kubeflow Pipelines",
             "ui:placeholder": "https://your-kubeflow-service:port/pipeline"

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -47,7 +47,7 @@
           "title": "Kubeflow Pipelines API Endpoint",
           "description": "The Kubeflow Pipelines API endpoint",
           "type": "string",
-          "pattern": "^((?:https?:\\/\\/)?[^./]+(?:\\.[^./]+)+(?:\\/.*)?)$",
+          "format": "uri",
           "uihints": {
             "category": "Kubeflow Pipelines",
             "ui:placeholder": "https://your-kubeflow-service:port/pipeline"

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -47,7 +47,7 @@
           "title": "Kubeflow Pipelines API Endpoint",
           "description": "The Kubeflow Pipelines API endpoint",
           "type": "string",
-          "format": "uri",
+          "pattern": "(?:(?:http|https)://)?(www\\.)?[a-zA-Z0-9@:%._\\+~#?&//=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%._\\+~#?&//=]*)",
           "uihints": {
             "category": "Kubeflow Pipelines",
             "ui:placeholder": "https://your-kubeflow-service:port/pipeline"

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -431,6 +431,8 @@ class RuntimePipelineProcessor(PipelineProcessor):
             raise ex from ex
 
     def _verify_cos_connectivity(self, runtime_configuration) -> None:
+        if not runtime_configuration.metadata['cos_endpoint'].startswith("https://"):
+            runtime_configuration.metadata['cos_endpoint'] = "https://" + runtime_configuration.metadata['cos_endpoint']
         self.log.debug(
             "Verifying cloud storage connectivity using runtime configuration "
             f"'{runtime_configuration.display_name}'."


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Modify logic so that API endpoint shoiuld have the URL scheme as an optional.

### How was this pull request tested?
1. Run `elyra-metadata list runtimes`.
2. Modify the api endpoint.
3. You should see that Elyra UI's runtime section loads the runtime without issue.

Fixes [RHOAIENG-5071](https://issues.redhat.com/browse/RHOAIENG-5071)
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
