### PR TITLE
Fix/python output to log window

### DIFF
--- a/elyra/kfp/bootstrapper.py
+++ b/elyra/kfp/bootstrapper.py
@@ -1,4 +1,4 @@
-# Copied from: https://github.com/elyra-ai/elyra/blob/main/elyra/kfp/bootstrapper.py
+#
 #
 # Copyright 2018-2023 Elyra Authors
 #

--- a/elyra/kfp/bootstrapper.py
+++ b/elyra/kfp/bootstrapper.py
@@ -1,3 +1,4 @@
+# Copied from: https://github.com/elyra-ai/elyra/blob/main/elyra/kfp/bootstrapper.py
 #
 # Copyright 2018-2023 Elyra Authors
 #
@@ -482,10 +483,19 @@ class PythonFileOp(FileOpBase):
             run_args = ["python3", python_script]
             if self.parameter_pass_method == "env":
                 self.set_parameters_in_env()
-
+            
+            logger.info("----------------------Python logs start----------------------")
             with open(python_script_output, "w") as log_file:
-                subprocess.run(run_args, stdout=log_file, stderr=subprocess.STDOUT, check=True)
-
+                process = subprocess.Popen(run_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                for line in iter(process.stdout.readline, b''):
+                    sys.stdout.write(line.decode())
+                    log_file.write(line.decode())
+                    
+                process.stdout.close()
+                return_code = process.wait()
+                logger.info("----------------------Python logs ends----------------------")
+                if return_code:
+                    raise subprocess.CalledProcessError(return_code, run_args)
             duration = time.time() - t0
             OpUtil.log_operation_info("python script execution completed", duration)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This updates the bootstrapper script to not only push outputs to an S3 storage but also pipe them to the normal log output.
This makes Elyra more usable for users who don't have an easy way to browse their S3 storage.

### How was this pull request tested?
This change was manually tested by:
1. Build a runtime image with the new bootstrapper.py
2. Push that runtime image to a registry (https://quay.io/repository/rlundber/pipelines-fix in my case)
3. Create a new runtime image in Elyra based on that image
4. Create a simple pipeline containing a python file like this: 
```
import logging

logging.basicConfig(level=logging.DEBUG,
                    format='%(asctime)s - %(levelname)s - %(message)s')

print("You should see this print")
logging.info("You should see this log")
raise Exception("Silly error you also should see")
```
5. Run the pipeline, go to the pod that runs the above file, and verify in the logs that the output is correct.