### PR TITLE
Fix 2 tests

### DIFF
--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -905,13 +905,13 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                 # Identify task inputs and outputs using the component spec
                 # If no data type was specified, string is assumed
                 factory_function = components.load_component_from_text(component.definition)
-                for input in factory_function.component_spec.inputs or []:
-                    sanitized_input_name = self._sanitize_param_name(input.name)
+                for input_key, input_value in (factory_function.component_spec.inputs or {}).items():
+                    sanitized_input_name = self._sanitize_param_name(input_key)
                     workflow_task["task_inputs"][sanitized_input_name] = {
                         "value": None,
                         "task_output_reference": None,
                         "pipeline_parameter_reference": None,
-                        "data_type": (input.type or "string").lower(),
+                        "data_type": (input_value.type or "string").lower(),
                     }
                     # Determine whether the value needs to be rendered in quotes
                     # in the generated DSL code. For example "my name" (string), and 34 (integer).
@@ -923,9 +923,9 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                         "bool",
                     ]
 
-                for output in factory_function.component_spec.outputs or []:
-                    workflow_task["task_outputs"][self._sanitize_param_name(output.name)] = {
-                        "data_type": output.type,
+                for output_key, output_value in (factory_function.component_spec.outputs or {}).items():
+                    workflow_task["task_outputs"][self._sanitize_param_name(output_key)] = {
+                        "data_type": output_value.type,
                     }
 
                 # Iterate over component properties and assign values to

--- a/elyra/tests/pipeline/resources/components/filter_text.yaml
+++ b/elyra/tests/pipeline/resources/components/filter_text.yaml
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Component source location: https://raw.githubusercontent.com/kubeflow/pipelines/master/components/sample/Shell_script/component.yaml
+# Component source location: https://raw.githubusercontent.com/kubeflow/pipelines/sdk-2.8.0/components/contrib/sample/Shell_script/component.yaml
 # Component details: Takes a text file and a regex pattern filter to produce a filtered text file
-name: Filter text
+name: Filter text using shell and grep
 inputs:
-- {name: Text, optional: false, description: 'Path to file to be filtered'}
-- {name: Pattern, optional: true, default: '.*', description: 'Regex pattern'}
+- {name: Text, type: String}
+- {name: Pattern, default: '.*', type: String}
 outputs:
-- {name: Filtered text}
+- {name: Filtered text, type: String}
 metadata:
   annotations:
     author: Alexey Volkov <alexey.volkov@ark-kun.com>
+    canonical_location: 'https://raw.githubusercontent.com/Ark-kun/pipeline_components/master/components/sample/Shell_script/component.yaml'
 implementation:
   container:
     image: alpine
@@ -34,8 +35,5 @@ implementation:
       pattern=$1
       filtered_text_path=$2
       mkdir -p "$(dirname "$filtered_text_path")"
-      
+
       grep "$pattern" < "$text_path" > "$filtered_text_path"
-    - {inputPath: Text}
-    - {inputValue: Pattern}
-    - {outputPath: Filtered text}


### PR DESCRIPTION
`test_generate_pipeline_dsl_compile_pipeline_dsl_custom_component_pipeline`
Remove Tekton part

`test_generate_pipeline_dsl_compile_pipeline_dsl_custom_components_with_parameters`
Adapt the YAML component and remove redundant checks

For both tests to pass, we also need a small change on `processor_kfp.py`. 
In KFP DSL v1, the inputs of a `Component` object are placed in a list but now it is a dictionary.
This is probably causing issues at runtime. 🤔 