### PR TITLE
RHOAIENG-11709: Adding a release github action 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
     env:
       FORCE_COLOR: "1"
     steps:
@@ -40,7 +41,7 @@ jobs:
         run: |
           set -o pipefail
           LATEST_TAG=$(git describe --tags --match="v*")
-          if [[ "$LATEST_TAG" != $(cat ./elyra/_version.py | grep "__version__" | cut -d'"' -f 2) ]]; then
+          if [[ "$LATEST_TAG" != "v$(cat ./elyra/_version.py | grep "__version__" | cut -d'"' -f 2)" ]]; then
             echo "::error title='$LATEST_TAG tag does not match project version'::"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,11 @@ jobs:
         run: |
           set -o pipefail
           LATEST_TAG=$(git describe --tags --match="v*")
-          if [[ "$LATEST_TAG" =~ $(cat ./elyra/_version.py | grep "__version__" | cut -d'"' -f 2) ]]; then
+          if [[ "$LATEST_TAG" != $(cat ./elyra/_version.py | grep "__version__" | cut -d'"' -f 2) ]]; then
             echo "::error title='$LATEST_TAG tag does not match project version'::"
             exit 1
           fi
+          echo "::info title='$LATEST_TAG tag is ready to be released to PyPI' ::"
       - name: Build package
         run: |
           make install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,76 +14,42 @@
 # limitations under the License.
 #
 name: Elyra Build and Release
-
 on:
+  push:
+    tags:
+      - v*
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version number for the release'
-        required: true
-      branch:
-        description: 'Branch to release from'
-        required: true
-
 jobs:
-  build:
-    uses: ./.github/workflows/build.yml
-
   release:
+    name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      FORCE_COLOR: "1"
     steps:
-      - name: Checkout code
+      - name: Check out the repository
         uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-
-      - name: Create release branch
+          python-version: "3.11"
+      - name: Check version
         run: |
-          git checkout -b rel-${{ github.event.inputs.version }} ${{ github.event.inputs.branch }}
-          git push -u origin rel-${{ github.event.inputs.version }}
-
-      - name: Update version file
-        run: |
-          # edits the version file in place
-          sed -i '' 's/^__version__ = ".*"/__version__ = "${{ github.event.inputs.version }}"/' elyra/_version.py
-          git config user.name "Edson Tirelli"
-          git config user.email ed.tirelli@github.com
-          git commit -m "Bump version to ${{ github.event.inputs.version }}" elyra/_version.py
-          git push
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install twine
-
+          set -o pipefail
+          LATEST_TAG=$(git describe --tags --match="v*")
+          if [[ "$LATEST_TAG" =~ $(cat ./elyra/_version.py | grep "__version__" | cut -d'"' -f 2) ]]; then
+            echo "::error title='$LATEST_TAG tag does not match project version'::"
+            exit 1
+          fi
       - name: Build package
-        run: make install
-
-#      - name: Release to PyPI
-#        env:
-#          TWINE_USERNAME: __token__
-#          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-#        run: |
-#          twine upload dist/*
-
-      - name: Create tag
-        if: success()
         run: |
-          git tag v${{ github.event.inputs.version }}
-          git push origin v${{ github.event.inputs.version }}
-
-#      - name: Create GitHub Release
-#        uses: actions/create-release@v1
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          tag_name: v${{ github.event.inputs.version }}
-#          release_name: Release ${{ github.event.inputs.version }}
-#          body: |
-#            Release version ${{ github.event.inputs.version }}
-#          draft: false
-#          prerelease: false
-
+          make install
+      - name: Publish package on PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          print-hash: true
+          packages-dir: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+#
+# Copyright 2018-2023 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Elyra Build and Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number for the release'
+        required: true
+      branch:
+        description: 'Branch to release from'
+        required: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Create release branch
+        run: |
+          git checkout -b rel-${{ github.event.inputs.version }} ${{ github.event.inputs.branch }}
+          git push -u origin rel-${{ github.event.inputs.version }}
+
+      - name: Update version file
+        run: |
+          # edits the version file in place
+          sed -i '' 's/^__version__ = ".*"/__version__ = "${{ github.event.inputs.version }}"/' elyra/_version.py
+          git config user.name "Edson Tirelli"
+          git config user.email ed.tirelli@github.com
+          git commit -m "Bump version to ${{ github.event.inputs.version }}" elyra/_version.py
+          git push
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine
+
+      - name: Build package
+        run: make install
+
+#      - name: Release to PyPI
+#        env:
+#          TWINE_USERNAME: __token__
+#          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+#        run: |
+#          twine upload dist/*
+
+      - name: Create tag
+        if: success()
+        run: |
+          git tag v${{ github.event.inputs.version }}
+          git push origin v${{ github.event.inputs.version }}
+
+#      - name: Create GitHub Release
+#        uses: actions/create-release@v1
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          tag_name: v${{ github.event.inputs.version }}
+#          release_name: Release ${{ github.event.inputs.version }}
+#          body: |
+#            Release version ${{ github.event.inputs.version }}
+#          draft: false
+#          prerelease: false
+


### PR DESCRIPTION
In order to publish the elyra packages to pypi, push a tag with the format `v<version>` to the repository.

Fixes: https://issues.redhat.com/browse/RHOAIENG-11709

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
