### PR TITLE
RHOAIENG-12850: Fix no warning is shown if a code snippet is added to a file with different language

### DIFF
--- a/packages/code-snippet/package.json
+++ b/packages/code-snippet/package.json
@@ -60,6 +60,7 @@
     "@jupyterlab/builder": "^4.2.5",
     "@jupyterlab/cells": "^4.2.5",
     "@jupyterlab/codeeditor": "^4.2.5",
+    "@jupyterlab/codemirror": "^4.2.5",
     "@jupyterlab/coreutils": "^6.0.6",
     "@jupyterlab/docmanager": "^4.2.5",
     "@jupyterlab/docregistry": "^4.2.5",

--- a/packages/code-snippet/src/CodeSnippetWidget.tsx
+++ b/packages/code-snippet/src/CodeSnippetWidget.tsx
@@ -43,6 +43,7 @@ import {
   IMarkdownCellModel /*RawCell*/
 } from '@jupyterlab/cells';
 import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
+import { EditorLanguageRegistry } from '@jupyterlab/codemirror';
 import { PathExt } from '@jupyterlab/coreutils';
 import { DocumentWidget } from '@jupyterlab/docregistry';
 import { FileEditor } from '@jupyterlab/fileeditor';
@@ -233,9 +234,10 @@ class CodeSnippetDisplay extends MetadataDisplay<ICodeSnippetDisplayProps> {
   private getEditorLanguage = (
     widget: DocumentWidget<FileEditor>
   ): string | undefined => {
-    const editorLanguage =
-      widget.context.sessionContext.kernelPreference.language;
-    return editorLanguage === 'null' ? '' : editorLanguage;
+    const editorLanguage = EditorLanguageRegistry.getDefaultLanguages().find(
+      (language) => language.mime.includes(widget.content.model.mimeType)
+    );
+    return editorLanguage?.displayName ?? '';
   };
 
   // Return the given code wrapped in a markdown code block

--- a/tests/integration/codesnippet.ts
+++ b/tests/integration/codesnippet.ts
@@ -238,8 +238,7 @@ describe('Code Snippet tests', () => {
     cy.get('.cm-editor .cm-content .cm-line').contains(/test/i);
   });
 
-  // Depends on https://issues.redhat.com/browse/RHOAIENG-12850
-  it.skip('should fail to insert a java code snippet into python editor', () => {
+  it('should fail to insert a java code snippet into python editor', () => {
     // Give time for the Launcher tab to load
     cy.wait(2000);
 
@@ -260,7 +259,7 @@ describe('Code Snippet tests', () => {
 
     // Check it did not insert the code
     cy.get('.cm-editor:visible');
-    cy.get('.cm-editor .cm-content .cm-line').should('not.exist');
+    cy.get('.cm-editor .cm-content .cm-line').should('not.contain', /test/i);
   });
 
   // DEV NOTE: Uncomment the tests below to run them locally

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,6 +3156,7 @@ __metadata:
     "@jupyterlab/builder": ^4.2.5
     "@jupyterlab/cells": ^4.2.5
     "@jupyterlab/codeeditor": ^4.2.5
+    "@jupyterlab/codemirror": ^4.2.5
     "@jupyterlab/coreutils": ^6.0.6
     "@jupyterlab/docmanager": ^4.2.5
     "@jupyterlab/docregistry": ^4.2.5


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-12850

Use `EditorLanguageRegistry` to resolve the editor language based on the model's mimeType. The previous approach is not applicable anymore. With this fix, one integration test is back alive.