### PR TITLE
RHOAIENG-12849: Fix `Tags` component style

### DIFF
--- a/packages/ui-components/src/FormComponents/Tags.tsx
+++ b/packages/ui-components/src/FormComponents/Tags.tsx
@@ -112,7 +112,7 @@ export const Tags: React.FC<ITagProps> = ({
   const inputBox =
     addingNewTag === true ? (
       <ul
-        className={`${FORM_EDITOR_TAG} tag unapplied-tag`}
+        className={`${FORM_EDITOR_TAG} jp-CellTags-Tag jp-CellTags-Unapplied`}
         key={'editor-new-tag'}
       >
         <input
@@ -134,7 +134,7 @@ export const Tags: React.FC<ITagProps> = ({
     ) : (
       <button
         onClick={(): void => setAddingNewTag(true)}
-        className={`${FORM_EDITOR_TAG} tag unapplied-tag`}
+        className={`${FORM_EDITOR_TAG} jp-CellTags-Tag jp-CellTags-Unapplied`}
       >
         Add Tag
         <addIcon.react
@@ -157,7 +157,7 @@ export const Tags: React.FC<ITagProps> = ({
                 return (
                   <button
                     onClick={handleClick}
-                    className={`${FORM_EDITOR_TAG} tag unapplied-tag`}
+                    className={`${FORM_EDITOR_TAG} jp-CellTags-Tag jp-CellTags-Unapplied`}
                     id={`editor-${tag}-${index}`}
                     key={`editor-${tag}-${index}`}
                   >
@@ -170,7 +170,7 @@ export const Tags: React.FC<ITagProps> = ({
                 return (
                   <button
                     onClick={handleClick}
-                    className={`${FORM_EDITOR_TAG} tag applied-tag`}
+                    className={`${FORM_EDITOR_TAG} jp-CellTags-Tag jp-CellTags-Applied`}
                     id={`editor-${tag}-${index}`}
                     key={`editor-${tag}-${index}`}
                   >
@@ -189,7 +189,7 @@ export const Tags: React.FC<ITagProps> = ({
                 return (
                   <button
                     onClick={handleClick}
-                    className={`${FORM_EDITOR_TAG} tag unapplied-tag`}
+                    className={`${FORM_EDITOR_TAG} jp-CellTags-Tag jp-CellTags-Unapplied`}
                     id={`editor-${tag}-${index}`}
                     key={`editor-${tag}-${index}`}
                   >


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-12849

**Before**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/b9ea0b28-9013-48c3-8e3b-4232de72dccf">



**After**

https://github.com/user-attachments/assets/58aa3628-ca84-4bc7-a7db-7c28b180c86a

