### PR TITLE
RHOAIENG-13167: Fix Tags component style used by the Filter tools

### DIFF
--- a/packages/metadata-common/src/FilterTools.tsx
+++ b/packages/metadata-common/src/FilterTools.tsx
@@ -109,7 +109,7 @@ export class FilterTools extends React.Component<
   renderAppliedTag(tag: string, index: string): JSX.Element {
     return (
       <button
-        className={`${FILTER_TAG} tag applied-tag`}
+        className={`${FILTER_TAG} jp-CellTags-Tag jp-CellTags-Applied`}
         id={'filter' + '-' + tag + '-' + index}
         key={'filter' + '-' + tag + '-' + index}
         title={tag}
@@ -132,7 +132,7 @@ export class FilterTools extends React.Component<
   renderUnappliedTag(tag: string, index: string): JSX.Element {
     return (
       <button
-        className={`${FILTER_TAG} tag unapplied-tag`}
+        className={`${FILTER_TAG} jp-CellTags-Tag jp-CellTags-Unapplied`}
         id={'filter' + '-' + tag + '-' + index}
         key={'filter' + '-' + tag + '-' + index}
         title={tag}
@@ -160,12 +160,12 @@ export class FilterTools extends React.Component<
     currentTags: string[],
     clickedTag: string
   ): string[] {
-    if (target.classList.contains('unapplied-tag')) {
-      target.classList.replace('unapplied-tag', 'applied-tag');
+    if (target.classList.contains('jp-CellTags-Unapplied')) {
+      target.classList.replace('jp-CellTags-Unapplied', 'jp-CellTags-Applied');
 
       currentTags.splice(-1, 0, clickedTag);
-    } else if (target.classList.contains('applied-tag')) {
-      target.classList.replace('applied-tag', 'unapplied-tag');
+    } else if (target.classList.contains('jp-CellTags-Applied')) {
+      target.classList.replace('jp-CellTags-Applied', 'jp-CellTags-Unapplied');
 
       const idx = currentTags.indexOf(clickedTag);
       currentTags.splice(idx, 1);


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-13167

Apply the same fix done in https://github.com/opendatahub-io/elyra/pull/41 since the code is duplicated.

Before

<img width="199" alt="Screenshot 2024-09-20 at 10 23 47" src="https://github.com/user-attachments/assets/ba2d4ff0-d692-4968-bb99-ffa5dbcd8080">

After

<img width="199" alt="image" src="https://github.com/user-attachments/assets/59559db0-e3e2-4fcd-b20d-bc7e8deb0d0f">


