### PR TITLE
RHOAIENG-13044: set ELYRA_FILE_BASE_PATH var for script embedded in runtime images

### DIFF
--- a/docs/source/recipes/running-elyra-in-air-gapped-environment.md
+++ b/docs/source/recipes/running-elyra-in-air-gapped-environment.md
@@ -62,5 +62,8 @@ During pipeline execution in the Kubeflow Pipelines or Apache Airflow environmen
         - `ELYRA_REQUIREMENTS_URL` (URL of `.../etc/generic/requirements-elyra.txt`)
     - For Apache Airflow:
         - `ELYRA_BOOTSTRAP_SCRIPT_URL` (URL of `.../elyra/airflow/bootstrapper.py`)
-        - `ELYRA_REQUIREMENTS_URL` (URL of `.../etc/generic/requirements-elyra.txt`)     
+        - `ELYRA_REQUIREMENTS_URL` (URL of `.../etc/generic/requirements-elyra.txt`)
+    
+  Alternatively, for Kubeflow Pipeline users can store the bootstrapper.py, pip.conf and requirements-elyra.txt files in the runtime container itself, so it could be used without having to set the above variables. The path to these files needs to be configured, so Elyra execution can pick it up.
+    - `ELYRA_FILE_BASE_PATH` (default `/opt/app-root/bin/utils`) 
 - **S3-compatible cloud storage for [generic components](../user_guide/pipeline-components.html#generic-components)**: When processing pipeline nodes that are implemented using [generic components](../user_guide/pipeline-components.html#generic-components), Elyra downloads the pipeline artifacts that were uploaded when the pipeline was exported or submitted.


### PR DESCRIPTION
set ELYRA_FILE_BASE_PATH var for using the script embedded in runtime images
Related-to: https://issues.redhat.com/browse/RHOAIENG-13044


Tested with notebook image: `quay.io/harshad16/datascience:patch1`

![elyra-runtime drawio](https://github.com/user-attachments/assets/32af43cb-31e9-487c-8c75-2038ecc04c56)

As the elyra component in workbench, isn't aware if the files are embedded in runtime images, 
thus, we expanded the command, to first verify, if the files already present, if yes, use them or else download from URL.


Notes: once this PR is merged and elyra is released.
https://github.com/opendatahub-io/notebooks/blob/main/jupyter/datascience/ubi9-python-3.11/setup-elyra.sh#L21-L24
These bits needs to be removed from workbenches for this to take effect fully.
