### PR TITLE
Upgrade requirement package with most compatible

### DIFF
--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -1062,7 +1062,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
         # meant for the opendatahub-io/Data-science-pipelines v2 use case
         # and should not be opened as PR against upstream Elyra
         elyra_github_org = os.getenv("ELYRA_GITHUB_ORG", "opendatahub-io")
-        elyra_github_branch = os.getenv("ELYRA_GITHUB_BRANCH", "dspv2" if "dev" in __version__ else __version__)
+        elyra_github_branch = os.getenv("ELYRA_GITHUB_BRANCH", "jupyterlab4" if "dev" in __version__ else __version__)
         elyra_bootstrap_script_url = os.getenv(
             "ELYRA_BOOTSTRAP_SCRIPT_URL",
             f"https://raw.githubusercontent.com/{elyra_github_org}/elyra/{elyra_github_branch}/elyra/kfp/bootstrapper.py",  # noqa E501

--- a/etc/generic/requirements-elyra.txt
+++ b/etc/generic/requirements-elyra.txt
@@ -1,22 +1,22 @@
 # This is a comprehensive list of python dependencies that Elyra requires to execute Jupyter notebooks.
-ipykernel==6.13.0
-ipython==8.10.0
+ipykernel==6.25.2
+ipython==8.12.3
 ipython-genutils==0.2.0
-jinja2==3.0.3
-jupyter-client==7.3.1
-jupyter-core==4.11.2
+jinja2==3.1.4
+jupyter-client==7.4.9
+jupyter-core==5.3.1
 MarkupSafe==2.1.1
-minio==7.1.8
+minio==7.1.15
 nbclient==0.6.3
-nbconvert==6.5.1
+nbconvert==7.1.0
 nbformat==5.4.0
-papermill==2.3.4
+papermill==2.6.0
 pyzmq==24.0.1
-prompt-toolkit==3.0.30
-requests==2.31.0
-tornado==6.3.3
-traitlets==5.1.1
-urllib3==1.26.18
+prompt-toolkit==3.0.43
+requests==2.32.3
+tornado==6.4.1
+traitlets==5.10.0
+urllib3==1.26.19
 #
 # These excluded are transitive dependencies of the included python packages.
 #ansiwrap==0.8.4


### PR DESCRIPTION
Upgrade requirement package with most compatible

Related-to: https://issues.redhat.com/browse/RHOAIENG-13044

- Cherry-picked upstream fixes: https://github.com/elyra-ai/elyra/pull/3240
This issue occurs on jupyterlab4 branch as well.

- change default elyra_github_branch to be pointed at jupyterlab4, till we do dev releases.