### PR TITLE
Use version `2.0.0` for `sphinx_rtd_theme`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx>=1.8
-sphinx_rtd_theme
+sphinx_rtd_theme==2.0.0
 recommonmark>=0.6.0
 sphinx-markdown-tables>=0.0.16
 sphinx-version-warning


### PR DESCRIPTION
The `Test Documentation Build` job started to fail on the weekend because `sphinx_rtd_theme` [released](https://github.com/readthedocs/sphinx_rtd_theme/tags) a new version that has deprecated things. Let's freeze the version that we were currently using to bring back the failing job to green.