### PR TITLE
RHOAIENG-12830: Add Elyra shortcuts to file explorer context menu

### DIFF
--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -191,10 +191,14 @@ const extension: JupyterFrontEndPlugin<void> = {
           return `New ${PIPELINE_EDITOR}`;
         }
         if (args.runtimeType?.id === 'LOCAL') {
-          return `Generic ${PIPELINE_EDITOR}`;
+          const contextMenuPrefix = args.isContextMenu ? 'New ' : '';
+          return `${contextMenuPrefix}Generic ${PIPELINE_EDITOR}`;
         }
         if (args.isMenu) {
           return `${args.runtimeType?.display_name} ${PIPELINE_EDITOR}`;
+        }
+        if (args.isContextMenu) {
+          return `New ${args.runtimeType?.display_name} ${PIPELINE_EDITOR}`;
         }
         return PIPELINE_EDITOR;
       },
@@ -297,6 +301,15 @@ const extension: JupyterFrontEndPlugin<void> = {
         if (launcher) {
           const fileMenuItems: IRankedMenu.IItemOptions[] = [];
 
+          let contextMenuRank = 100;
+
+          app.contextMenu.addItem({
+            command: openPipelineEditorCommand,
+            type: 'separator',
+            selector: '.jp-DirListing-content',
+            rank: ++contextMenuRank
+          });
+
           for (const t of resolvedTypes as any) {
             launcher.add({
               command: openPipelineEditorCommand,
@@ -310,7 +323,21 @@ const extension: JupyterFrontEndPlugin<void> = {
               args: { runtimeType: t, isMenu: true },
               rank: t.id === 'LOCAL' ? 90 : 91
             });
+
+            app.contextMenu.addItem({
+              command: openPipelineEditorCommand,
+              args: { runtimeType: t, isContextMenu: true },
+              selector: '.jp-DirListing-content',
+              rank: ++contextMenuRank
+            });
           }
+
+          app.contextMenu.addItem({
+            command: openPipelineEditorCommand,
+            type: 'separator',
+            selector: '.jp-DirListing-content',
+            rank: ++contextMenuRank
+          });
 
           menu.fileMenu.newMenu.addGroup(fileMenuItems);
         }

--- a/packages/python-editor/src/index.ts
+++ b/packages/python-editor/src/index.ts
@@ -274,7 +274,9 @@ const extension: JupyterFrontEndPlugin<void> = {
     // Add a command to create new Python editor
     app.commands.addCommand(commandIDs.createNewPythonEditor, {
       label: (args) =>
-        args['isPalette'] ? 'New Python Editor' : 'Python Editor',
+        args['isPalette'] || args['isContextMenu']
+          ? 'New Python Editor'
+          : 'Python Editor',
       caption: 'Create a new Python Editor',
       icon: (args) => (args['isPalette'] ? undefined : pythonIcon),
       execute: (args) => {
@@ -287,6 +289,13 @@ const extension: JupyterFrontEndPlugin<void> = {
       command: commandIDs.createNewPythonEditor,
       args: { isPalette: true },
       category: 'Elyra'
+    });
+
+    app.contextMenu.addItem({
+      command: commandIDs.createNewPythonEditor,
+      args: { isContextMenu: true },
+      selector: '.jp-DirListing-content',
+      rank: 200
     });
   }
 };

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -141,6 +141,13 @@ describe('Pipeline Editor tests', () => {
     checkEnabledToolbarButtons(enabledButtons);
   });
 
+  it('opens blank Pipeline editor from file explorer context menu', () => {
+    cy.get('.jp-FileBrowser').should('be.visible');
+    cy.get('.jp-DirListing-content').rightclick();
+    cy.get('.lm-Menu').contains('New Generic Pipeline Editor').click();
+    cy.closeTab(-1);
+  });
+
   it('matches complex pipeline snapshot', () => {
     cy.bootstrapFile('pipelines/consumer.ipynb');
     cy.bootstrapFile('pipelines/create-source-files.py');

--- a/tests/integration/pythoneditor.ts
+++ b/tests/integration/pythoneditor.ts
@@ -60,6 +60,13 @@ describe('Python Editor tests', () => {
     cy.closeTab(-1);
   });
 
+  it('opens blank Python editor from file explorer context menu', () => {
+    cy.get('.jp-FileBrowser').should('be.visible');
+    cy.get('.jp-DirListing-content').rightclick();
+    cy.get('.lm-Menu').contains('New Python Editor').click();
+    cy.closeTab(-1);
+  });
+
   it('check toolbar and its content for Python file', () => {
     cy.createNewScriptEditor('Python');
     cy.checkScriptEditorToolbarContent();


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-12830

Add entries for Pipeline and Python editors.

Result:

https://github.com/user-attachments/assets/ac1bf984-f509-4861-8577-139dddf5f6ec

I've added separators so that it looks similar to the "File -> New" menu:

<img width="430" alt="image" src="https://github.com/user-attachments/assets/d3811134-f103-45cd-8f14-a371d0a6775b">
