### PR TITLE
RHOAIENG-13010: Fix create new node from context menu

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -480,7 +480,7 @@ const PipelineWrapper: React.FC<IProps> = ({
       contextRef.current.path,
       args.filename ?? ''
     );
-    if (args.propertyID.includes('dependencies')) {
+    if (args.propertyID?.includes('dependencies')) {
       const res = await showBrowseFileDialog(browserFactory.model.manager, {
         multiselect: true,
         includeDir: true,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-13010

Note: It has the behavior of listing the files from the parent folder, just like browsing the input or file dependencies. We should probably review this behavior.


https://github.com/user-attachments/assets/9f3eddb9-336f-473d-b9a6-45a31b776a2d

