### PR TITLE
RHOAIENG-13909: Script and workflow to bump Elyra's version

### DIFF
--- a/.github/workflows/scripts/update_version.sh
+++ b/.github/workflows/scripts/update_version.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <NEW_VERSION>"
+  exit 1
+fi
+
+NEW_VERSION=$1
+
+echo "Updating version in UI packages ..."
+npx lerna@8.1.8 version "$NEW_VERSION" --no-git-tag-version --no-push --yes
+
+echo "Formatting files ..."
+make prettier-ui
+
+echo "Updating version in elyra/_version.py ..."
+sed -i.bak "s/__version__ = \".*\"/__version__ = \"$NEW_VERSION\"/" elyra/_version.py && rm elyra/_version.py.bak
+
+echo "Version successfully updated to $NEW_VERSION"

--- a/.github/workflows/update-version-through-pr.yml
+++ b/.github/workflows/update-version-through-pr.yml
@@ -1,0 +1,66 @@
+name: Update version through Pull Request
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version'
+        required: true
+      source_branch:
+        description: 'Source branch to update the version'
+        required: true
+        default: 'main'
+      target_branch:
+        description: 'Target branch for the pull request'
+        required: true
+
+env:
+  NODE_VERSION: 20.11.0
+  YARN_VERSION: 3.5.0
+
+jobs:
+  update_version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.source_branch }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Yarn ${{ env.YARN_VERSION }}
+        run: |
+          corepack prepare yarn@${{ env.YARN_VERSION }} --activate
+          yarn set version ${{ env.YARN_VERSION }}
+          git checkout package.json
+          yarn --version
+
+      - name: Install dependencies
+        run: |
+          make yarn-install
+
+      - name: Update version to ${{ github.event.inputs.version }}
+        id: update
+        run: |
+          ./.github/workflows/scripts/update_version.sh ${{ github.event.inputs.version }}
+
+          # Clean up yarn setup changes
+          git checkout .yarnrc.yml
+
+          TIMESTAMP=$(date +'%Y%m%d%H%M%S')
+          SYNC_BRANCH=update-version__${{ github.event.inputs.version }}__${TIMESTAMP}
+          echo "branch=$SYNC_BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Create a pull request
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        with:
+          branch: ${{ steps.update.outputs.branch }}
+          base: ${{ github.event.inputs.target_branch }}
+          title: 'Update version to `${{ github.event.inputs.version }}`'
+          body: ':robot: This is an automated PR created by `/.github/workflows/update-version-through-pr.yml` to update the project version to `${{ github.event.inputs.version }}`.'

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,6 @@
       "message": "chore(release): publish"
     }
   },
-  "packages": ["packages/*"]
+  "packages": ["packages/*"],
+  "exact": true
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-13909

Validation:
- From `main` to a release branch (`0.0.0` -> `4.1.0`): https://github.com/caponetto/opendatahub-io-elyra/pull/6
- From `v4.0.x` to itself (`4.0.3` -> `4.2.0`): https://github.com/caponetto/opendatahub-io-elyra/pull/8

**NOTE**: The source branch must have these scripts included, otherwise the workflow will fail.