### PR TITLE
RHOAIENG-13877: Fix kernel dropdown style for Dark theme

### DIFF
--- a/packages/script-editor/src/KernelDropdown.tsx
+++ b/packages/script-editor/src/KernelDropdown.tsx
@@ -16,6 +16,7 @@
 
 import { ReactWidget } from '@jupyterlab/apputils';
 import { KernelSpec } from '@jupyterlab/services';
+import { HTMLSelect } from '@jupyterlab/ui-components';
 
 import React, {
   forwardRef,
@@ -24,8 +25,6 @@ import React, {
   useMemo,
   RefObject
 } from 'react';
-
-const KERNEL_SELECT_CLASS = 'elyra-ScriptEditor-KernelSelector';
 
 export interface ISelect {
   getSelection: () => string;
@@ -73,13 +72,9 @@ const DropDown = forwardRef<ISelect, IProps>(
     };
 
     return (
-      <select
-        className={KERNEL_SELECT_CLASS}
-        onChange={handleSelection}
-        value={selection}
-      >
+      <HTMLSelect onChange={handleSelection} value={selection}>
         {kernelOptions}
-      </select>
+      </HTMLSelect>
     );
   }
 );

--- a/packages/script-editor/style/index.css
+++ b/packages/script-editor/style/index.css
@@ -74,21 +74,3 @@ button.elyra-ScriptEditor-scrollBottom:hover {
 .jp-Document .jp-Toolbar.elyra-ScriptEditor-Toolbar {
   justify-content: flex-start;
 }
-
-/* TODO: fix selector not beig picked up */
-/* fix border style in safari */
-.elyra-ScriptEditor-KernelSelector select {
-  background-color: initial;
-  border: none;
-  border-radius: 0;
-  box-shadow: none;
-  color: var(--jp-ui-font-color0);
-  display: block;
-  font-size: var(--jp-ui-font-size1);
-  height: 24px;
-  line-height: 14px;
-  padding: 0 25px 0 10px;
-  text-align: left;
-  -moz-appearance: none;
-  -webkit-appearance: none;
-}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-13877

Use the `HTMLSelect` component from `@jupyterlab/ui-components` just like the Python Notebook does.

https://github.com/user-attachments/assets/b48d1aa1-deec-4e07-a7f1-80957b1ed63c

