### PR TITLE
ci: Improve tag resolution on the Build notebook images step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,9 +289,7 @@ jobs:
 
           URLS=""
           for tag_prefix in $(echo "${{ env.QUAY_WORKBENCH_IMAGES_TAG_PREFIX_CSV }}" | tr ',' '\n'); do
-            LATEST_TAG=$(curl -s "https://quay.io/api/v1/repository/${{ env.QUAY_WORKBENCH_IMAGES_REPOSITORY}}/tag/?onlyActiveTags=true" | \
-              jq -r ".tags | map(select(.name | startswith(\"${tag_prefix}\"))) | .[].name" | \
-              sort -r | head -n 1)
+            LATEST_TAG=$(curl -s "https://quay.io/api/v1/repository/${{ env.QUAY_WORKBENCH_IMAGES_REPOSITORY}}/tag/?onlyActiveTags=true&filter_tag_name=like:${tag_prefix}&limit=1" | jq -r ".tags[].name")
             echo "Latest tag: $LATEST_TAG"
 
             CONTAINER_IMAGE=ghcr.io/${{ github.repository }}/workbench-images:${LATEST_TAG}${TAG_SUFFIX}


### PR DESCRIPTION
As the newest tag comes first, use `filter_tag_name=like:<tag_prefix>` and `limit=1` instead of fetching/sorting all the tags and picking the first one, which is paginated and could lead to issues.

Validation: https://github.com/caponetto/opendatahub-io-elyra/actions/runs/11665431548/job/32478187063