### PR TITLE
Fix new failures on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,9 @@ release: yarn-install build-ui-prod build-server ## Build wheel file for release
 
 
 elyra-image-env: ## Creates a conda env consisting of the dependencies used in images
-	conda env remove -y -n $(ELYRA_IMAGE_ENV)
+	@conda env list | grep -q "$(ELYRA_IMAGE_ENV)" && \
+		conda env remove -y -n $(ELYRA_IMAGE_ENV) || \
+		echo "Environment $(ELYRA_IMAGE_ENV) does not exist, skipping removal"
 	conda create -y -n $(ELYRA_IMAGE_ENV) python=$(PYTHON_VERSION) --channel conda-forge
 	$(CONDA_ACTIVATE) $(ELYRA_IMAGE_ENV) && \
 	$(PYTHON_PIP) install -r etc/generic/requirements-elyra.txt && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "yaspin",
     # see: https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli
     "appengine-python-standard",
-    "kfp>=2.0.0", # Cap kfp for protobuff compatibility
+    "kfp==2.9.0", # Cap kfp for protobuff compatibility
     "kfp-kubernetes>=1.0.0",
     "pygithub",
     "black>=22.8.0",


### PR DESCRIPTION
In this PR:
- As the CI started to throw `EnvironmentLocationNotFound`, add a check to run `conda env remove` only if the env exists.
- Cap `kfp` to the exact version we've been using for a while (`==2.9.0`). The new `v2.10.0` release brings breaking changes so it can be updated in a separate PR.