### PR TITLE
RHOAIENG-14040: Replace 'any' with correct types in typescript code

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,7 @@
     "@typescript-eslint/no-unused-vars": ["warn", { "args": "none" }],
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/camelcase": "off",
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-namespace": "off",
     "header/header": [

--- a/packages/code-snippet/src/CodeSnippetService.ts
+++ b/packages/code-snippet/src/CodeSnippetService.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { IMetadata } from '@elyra/metadata-common';
-import { MetadataService } from '@elyra/services';
+import { IMetadataResource, MetadataService } from '@elyra/services';
 
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 
@@ -23,15 +22,15 @@ export const CODE_SNIPPET_SCHEMASPACE = 'code-snippets';
 export const CODE_SNIPPET_SCHEMA = 'code-snippet';
 
 export class CodeSnippetService {
-  static async findAll(): Promise<IMetadata[]> {
-    return MetadataService.getMetadata(CODE_SNIPPET_SCHEMASPACE);
+  static async findAll(): Promise<IMetadataResource[]> {
+    return (await MetadataService.getMetadata(CODE_SNIPPET_SCHEMASPACE)) ?? [];
   }
 
   // TODO: Test this function
-  static async findByLanguage(language: string): Promise<IMetadata[]> {
+  static async findByLanguage(language: string): Promise<IMetadataResource[]> {
     try {
-      const allCodeSnippets: IMetadata[] = await this.findAll();
-      const codeSnippetsByLanguage: IMetadata[] = [];
+      const allCodeSnippets = await this.findAll();
+      const codeSnippetsByLanguage: IMetadataResource[] = [];
 
       for (const codeSnippet of allCodeSnippets) {
         if (codeSnippet.metadata.language === language) {
@@ -54,11 +53,11 @@ export class CodeSnippetService {
    * @returns A boolean promise that is true if the dialog confirmed
    * the deletion, and false if the deletion was cancelled.
    */
-  static deleteCodeSnippet(codeSnippet: IMetadata): Promise<boolean> {
+  static deleteCodeSnippet(codeSnippet: IMetadataResource): Promise<boolean> {
     return showDialog({
       title: `Delete snippet '${codeSnippet.display_name}'?`,
       buttons: [Dialog.cancelButton(), Dialog.okButton()]
-    }).then((result: any) => {
+    }).then((result) => {
       // Do nothing if the cancel button is pressed
       if (result.button.accept) {
         return MetadataService.deleteMetadata(

--- a/packages/metadata-common/src/MetadataCommonService.tsx
+++ b/packages/metadata-common/src/MetadataCommonService.tsx
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import { MetadataService } from '@elyra/services';
-
-import { IMetadata } from './MetadataWidget';
+import { IMetadataResource, MetadataService } from '@elyra/services';
 
 export class MetadataCommonService {
   /**
@@ -31,9 +29,9 @@ export class MetadataCommonService {
    */
   static duplicateMetadataInstance(
     schemaSpace: string,
-    metadataInstance: IMetadata,
-    existingInstances: IMetadata[]
-  ): Promise<boolean> {
+    metadataInstance: IMetadataResource,
+    existingInstances: IMetadataResource[]
+  ): Promise<IMetadataResource | undefined> {
     // iterate through the list of currently defined
     // instance names and find the next available one
     // using '<source-instance-name>-Copy<N>'
@@ -56,9 +54,6 @@ export class MetadataCommonService {
     const duplicated_metadata = JSON.parse(JSON.stringify(metadataInstance));
     duplicated_metadata.display_name = `${base_name}-Copy${count}`;
     delete duplicated_metadata.name;
-    return MetadataService.postMetadata(
-      schemaSpace,
-      JSON.stringify(duplicated_metadata)
-    );
+    return MetadataService.postMetadata(schemaSpace, duplicated_metadata);
   }
 }

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -88,12 +88,12 @@ export const MetadataEditor: React.FC<IMetadataEditorComponentProps> = ({
   /**
    * Saves metadata through either put or post request.
    */
-  const saveMetadata = (): void => {
+  const saveMetadata = () => {
     if (invalidForm) {
       return;
     }
 
-    const newMetadata: any = {
+    const newMetadata = {
       schema_name: schemaName,
       display_name: metadata?.['_noCategory']?.['display_name'],
       metadata: flattenFormData(metadata)
@@ -101,7 +101,7 @@ export const MetadataEditor: React.FC<IMetadataEditorComponentProps> = ({
 
     if (!name) {
       MetadataService.postMetadata(schemaspace, JSON.stringify(newMetadata))
-        .then((response: any): void => {
+        .then(() => {
           setDirty(false);
           onSave();
           close();
@@ -113,7 +113,7 @@ export const MetadataEditor: React.FC<IMetadataEditorComponentProps> = ({
         name,
         JSON.stringify(newMetadata)
       )
-        .then((response: any): void => {
+        .then(() => {
           setDirty(false);
           onSave();
           close();

--- a/packages/metadata-common/src/MetadataWidget.tsx
+++ b/packages/metadata-common/src/MetadataWidget.tsx
@@ -271,18 +271,18 @@ export class MetadataDisplay<
   };
 
   getActiveTags(): string[] {
-    const tags: string[] = [];
+    const activeTags: string[] = [];
     for (const metadata of this.props.metadata) {
-      const tags = metadata.metadata.tags as string[] | undefined;
-      if (tags) {
-        for (const tag of tags) {
-          if (!tags.includes(tag)) {
-            tags.push(tag);
+      const metadataTags = metadata.metadata.tags as string[] | undefined;
+      if (metadataTags) {
+        for (const tag of metadataTags) {
+          if (!activeTags.includes(tag)) {
+            activeTags.push(tag);
           }
         }
       }
     }
-    return tags;
+    return activeTags;
   }
 
   matchesTags(filterTags: Set<string>, metadata: IMetadataResource): boolean {

--- a/packages/metadata-common/src/MetadataWidget.tsx
+++ b/packages/metadata-common/src/MetadataWidget.tsx
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
-import { IDictionary, MetadataService } from '@elyra/services';
+import {
+  IMetadataResource,
+  ISchemaResource,
+  MetadataService
+} from '@elyra/services';
 import {
   ExpandableComponent,
+  GenericObjectType,
+  IErrorResponse,
   JSONComponent,
   RequestErrors,
   trashIcon
@@ -36,6 +42,10 @@ import {
   LabIcon,
   refreshIcon
 } from '@jupyterlab/ui-components';
+import {
+  ReadonlyJSONObject,
+  ReadonlyPartialJSONObject
+} from '@lumino/coreutils';
 import { Message } from '@lumino/messaging';
 import { Signal } from '@lumino/signaling';
 
@@ -57,13 +67,6 @@ const commands = {
   OPEN_METADATA_EDITOR: 'elyra-metadata-editor:open'
 };
 
-export interface IMetadata {
-  name: string;
-  display_name: string;
-  metadata: IDictionary<any>;
-  schema_name: string;
-}
-
 export interface IMetadataActionButton {
   title: string;
   icon: LabIcon;
@@ -71,18 +74,27 @@ export interface IMetadataActionButton {
   onClick: () => void;
 }
 
+export interface IOpenMetadataEditorArgs {
+  titleContext?: string;
+  schema: string;
+  schemaspace: string;
+  name?: string;
+  onSave: () => void;
+  code?: string[];
+}
+
 /**
  * MetadataDisplay props.
  */
 export interface IMetadataDisplayProps {
-  metadata: IMetadata[];
-  openMetadataEditor: (args: any) => void;
+  metadata: IMetadataResource[];
+  openMetadataEditor: (args: IOpenMetadataEditorArgs) => void;
   updateMetadata: () => void;
   schemaspace: string;
   sortMetadata: boolean;
   className: string;
   titleContext?: string;
-  labelName?: (args: any) => string;
+  labelName?: (args: IMetadataResource) => string;
   omitTags?: boolean;
 }
 
@@ -90,11 +102,14 @@ export interface IMetadataDisplayProps {
  * MetadataDisplay state.
  */
 export interface IMetadataDisplayState {
-  metadata: IMetadata[];
+  metadata: IMetadataResource[];
   searchValue: string;
   filterTags: string[];
-  matchesSearch: (searchValue: string, metadata: IMetadata) => boolean;
-  matchesTags: (filterTags: Set<string>, metadata: IMetadata) => boolean;
+  matchesSearch: (searchValue: string, metadata: IMetadataResource) => boolean;
+  matchesTags: (
+    filterTags: Set<string>,
+    metadata: IMetadataResource
+  ) => boolean;
 }
 
 /**
@@ -115,24 +130,26 @@ export class MetadataDisplay<
     };
   }
 
-  deleteMetadata = (metadata: IMetadata): Promise<void> => {
+  deleteMetadata = (metadata: IMetadataResource): Promise<void> => {
     return showDialog({
       title: `Delete ${
         this.props.labelName ? this.props.labelName(metadata) : ''
       } ${this.props.titleContext || ''} '${metadata.display_name}'?`,
       buttons: [Dialog.cancelButton(), Dialog.okButton()]
-    }).then((result: any) => {
+    }).then((result) => {
       // Do nothing if the cancel button is pressed
       if (result.button.accept) {
         MetadataService.deleteMetadata(
           this.props.schemaspace,
           metadata.name
-        ).catch((error) => RequestErrors.serverError(error));
+        ).catch(async (error) => {
+          await RequestErrors.serverError(error);
+        });
       }
     });
   };
 
-  actionButtons(metadata: IMetadata): IMetadataActionButton[] {
+  actionButtons(metadata: IMetadataResource): IMetadataActionButton[] {
     return [
       {
         title: 'Edit',
@@ -155,17 +172,19 @@ export class MetadataDisplay<
             metadata,
             this.props.metadata
           )
-            .then((response: any): void => {
+            .then((): void => {
               this.props.updateMetadata();
             })
-            .catch((error) => RequestErrors.serverError(error));
+            .catch(async (error) => {
+              await RequestErrors.serverError(error);
+            });
         }
       },
       {
         title: 'Delete',
         icon: trashIcon,
         onClick: (): void => {
-          this.deleteMetadata(metadata).then((response: any): void => {
+          this.deleteMetadata(metadata).then((): void => {
             this.props.updateMetadata();
           });
         }
@@ -176,7 +195,7 @@ export class MetadataDisplay<
   /**
    * Classes that extend MetadataWidget should override this
    */
-  renderExpandableContent(metadata: IDictionary<any>): JSX.Element {
+  renderExpandableContent(metadata: IMetadataResource): JSX.Element {
     const metadataWithoutTags = metadata.metadata;
     delete metadataWithoutTags.tags;
     return (
@@ -187,7 +206,7 @@ export class MetadataDisplay<
   }
 
   // Render display of metadata list
-  renderMetadata = (metadata: IMetadata): JSX.Element => {
+  renderMetadata = (metadata: IMetadataResource): JSX.Element => {
     return (
       <div
         key={metadata.name}
@@ -198,7 +217,7 @@ export class MetadataDisplay<
       >
         <ExpandableComponent
           displayName={metadata.display_name}
-          tooltip={metadata.metadata.description}
+          tooltip={metadata.metadata.description as string}
           actionButtons={this.actionButtons(metadata)}
         >
           <div id={metadata.name}>{this.renderExpandableContent(metadata)}</div>
@@ -221,7 +240,7 @@ export class MetadataDisplay<
   filteredMetadata = (searchValue: string, filterTags: string[]): void => {
     // filter with search
     let filteredMetadata = this.props.metadata.filter(
-      (metadata: IMetadata, index: number, array: IMetadata[]): boolean => {
+      (metadata: IMetadataResource): boolean => {
         return (
           metadata.name.toLowerCase().includes(searchValue.toLowerCase()) ||
           metadata.display_name
@@ -235,8 +254,9 @@ export class MetadataDisplay<
     if (filterTags.length !== 0) {
       filteredMetadata = filteredMetadata.filter((metadata) => {
         return filterTags.some((tag) => {
-          if (metadata.metadata.tags) {
-            return metadata.metadata.tags.includes(tag);
+          const tags = metadata.metadata.tags as string[] | undefined;
+          if (tags) {
+            return tags.includes(tag);
           }
           return false;
         });
@@ -253,8 +273,9 @@ export class MetadataDisplay<
   getActiveTags(): string[] {
     const tags: string[] = [];
     for (const metadata of this.props.metadata) {
-      if (metadata.metadata.tags) {
-        for (const tag of metadata.metadata.tags) {
+      const tags = metadata.metadata.tags as string[] | undefined;
+      if (tags) {
+        for (const tag of tags) {
           if (!tags.includes(tag)) {
             tags.push(tag);
           }
@@ -264,17 +285,16 @@ export class MetadataDisplay<
     return tags;
   }
 
-  matchesTags(filterTags: Set<string>, metadata: IMetadata): boolean {
+  matchesTags(filterTags: Set<string>, metadata: IMetadataResource): boolean {
     // True if there are no tags selected or if there are tags that match
     // tags of metadata
+    const tags = metadata.metadata.tags as string[];
     return (
-      filterTags.size === 0 ||
-      (metadata.metadata.tags &&
-        metadata.metadata.tags.some((tag: string) => filterTags.has(tag)))
+      filterTags.size === 0 || tags?.some((tag: string) => filterTags.has(tag))
     );
   }
 
-  matchesSearch(searchValue: string, metadata: IMetadata): boolean {
+  matchesSearch(searchValue: string, metadata: IMetadataResource): boolean {
     searchValue = searchValue.toLowerCase();
     // True if search string is in name or display_name,
     // or if the search string is empty
@@ -353,9 +373,9 @@ export interface IMetadataWidgetProps {
  * A abstract widget for viewing metadata.
  */
 export class MetadataWidget extends ReactWidget {
-  renderSignal: Signal<this, any>;
+  renderSignal: Signal<this, IMetadataResource[]>;
   props: IMetadataWidgetProps;
-  schemas?: IDictionary<any>[];
+  schemas?: ISchemaResource[];
   titleContext?: string;
   addLabel?: string;
   refreshButtonTooltip?: string;
@@ -365,7 +385,7 @@ export class MetadataWidget extends ReactWidget {
     this.addClass('elyra-metadata');
 
     this.props = props;
-    this.renderSignal = new Signal<this, any>(this);
+    this.renderSignal = new Signal<this, IMetadataResource[]>(this);
     this.titleContext = props.titleContext;
     this.addLabel = props.addLabel;
     this.fetchMetadata = this.fetchMetadata.bind(this);
@@ -383,7 +403,9 @@ export class MetadataWidget extends ReactWidget {
     try {
       this.schemas = await MetadataService.getSchema(this.props.schemaspace);
       const sortedSchema =
-        this.schemas?.sort((a, b) => a.title.localeCompare(b.title)) ?? [];
+        this.schemas?.sort((a, b) =>
+          (a.title ?? '').localeCompare(b.title ?? '')
+        ) ?? [];
       if (sortedSchema.length > 1) {
         for (const schema of sortedSchema) {
           this.props.app.contextMenu.addItem({
@@ -397,13 +419,13 @@ export class MetadataWidget extends ReactWidget {
               titleContext: this.props.titleContext,
               addLabel: this.props.addLabel,
               appendToTitle: this.props.appendToTitle
-            } as any
+            } as unknown as ReadonlyJSONObject
           });
         }
       }
       this.update();
     } catch (error) {
-      RequestErrors.serverError(error);
+      await RequestErrors.serverError(error as IErrorResponse);
     }
   }
 
@@ -424,16 +446,20 @@ export class MetadataWidget extends ReactWidget {
    *
    * @returns metadata in the format expected by `renderDisplay`
    */
-  async fetchMetadata(): Promise<any> {
+  async fetchMetadata(): Promise<IMetadataResource[] | undefined> {
     try {
       return await MetadataService.getMetadata(this.props.schemaspace);
     } catch (error) {
-      return RequestErrors.serverError(error);
+      await RequestErrors.serverError(error as IErrorResponse);
+      return;
     }
   }
 
   updateMetadata(): void {
-    this.fetchMetadata().then((metadata: any[]) => {
+    this.fetchMetadata().then((metadata) => {
+      if (!metadata) {
+        return;
+      }
       this.renderSignal.emit(metadata);
     });
   }
@@ -443,17 +469,23 @@ export class MetadataWidget extends ReactWidget {
   }
 
   // Triggered when the widget button on side panel is clicked
-  onAfterShow(msg: Message): void {
+  onAfterShow(_msg: Message): void {
     this.updateMetadata();
   }
 
-  openMetadataEditor = (args: any): void => {
-    this.props.app.commands.execute(commands.OPEN_METADATA_EDITOR, args);
+  openMetadataEditor = (args: IOpenMetadataEditorArgs): void => {
+    this.props.app.commands.execute(
+      commands.OPEN_METADATA_EDITOR,
+      args as unknown as ReadonlyPartialJSONObject
+    );
   };
 
   omitTags(): boolean {
     for (const schema of this.schemas ?? []) {
-      if (schema.properties?.metadata?.properties?.tags) {
+      const metadata = schema.properties?.metadata as
+        | GenericObjectType
+        | undefined;
+      if (metadata?.properties?.tags) {
         return false;
       }
     }
@@ -465,7 +497,7 @@ export class MetadataWidget extends ReactWidget {
    *
    * @returns a rendered instance of `MetadataDisplay`
    */
-  renderDisplay(metadata: IMetadata[]): React.ReactElement {
+  renderDisplay(metadata: IMetadataResource[]): React.ReactElement {
     if (Array.isArray(metadata) && !metadata.length) {
       // Empty metadata
       return (
@@ -528,10 +560,11 @@ export class MetadataWidget extends ReactWidget {
                 singleSchema
                   ? (): void =>
                       this.addMetadata(
-                        this.schemas?.[0].name,
+                        this.schemas?.[0].name ?? '',
                         this.titleContext
                       )
-                  : (event: any): void => {
+                  : // eslint-disable-next-line @typescript-eslint/no-explicit-any -- types mismatch
+                    (event: any): void => {
                       this.props.app.contextMenu.open(event);
                     }
               }
@@ -542,7 +575,9 @@ export class MetadataWidget extends ReactWidget {
           </div>
         </header>
         <UseSignal signal={this.renderSignal} initialArgs={[]}>
-          {(_, metadata): React.ReactElement => this.renderDisplay(metadata)}
+          {(_, metadata): React.ReactElement =>
+            this.renderDisplay(metadata ?? [])
+          }
         </UseSignal>
       </div>
     );

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -88,6 +88,7 @@
     "react-redux": "^7.2.0",
     "react-scripts": "4.0.3",
     "react-toastify": "^9.0.8",
+    "redux": "^4.2.0",
     "swr": "^0.5.6",
     "uuid": "^3.4.0"
   },

--- a/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
+++ b/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
@@ -20,7 +20,6 @@ import {
   IMetadata,
   MetadataDisplay,
   IMetadataDisplayProps,
-  //IMetadataDisplayState,
   IMetadataActionButton
 } from '@elyra/metadata-common';
 import { IDictionary, MetadataService } from '@elyra/services';
@@ -36,13 +35,6 @@ export const COMPONENT_CATALOGS_SCHEMASPACE = 'component-catalogs';
 
 const COMPONENT_CATALOGS_CLASS = 'elyra-metadata-component-catalogs';
 
-const handleError = (error: any): void => {
-  // silently eat a 409, the server will log in in the console
-  if (error.status !== 409) {
-    RequestErrors.serverError(error);
-  }
-};
-
 /**
  * A React Component for displaying the component catalogs list.
  */
@@ -54,7 +46,7 @@ class ComponentCatalogsDisplay extends MetadataDisplay<IMetadataDisplayProps> {
         icon: refreshIcon,
         onClick: (): void => {
           PipelineService.refreshComponentsCache(metadata.name)
-            .then((response: any): void => {
+            .then((): void => {
               this.props.updateMetadata();
             })
             .catch((error) =>
@@ -183,10 +175,15 @@ export class ComponentCatalogsWidget extends MetadataWidget {
 
   refreshMetadata(): void {
     PipelineService.refreshComponentsCache()
-      .then((response: any): void => {
+      .then((): void => {
         this.updateMetadataAndRefresh();
       })
-      .catch((error) => handleError(error));
+      .catch((error) => {
+        // silently eat a 409, the server will log in in the console
+        if (error.status !== 409) {
+          RequestErrors.serverError(error);
+        }
+      });
   }
 
   renderDisplay(metadata: IMetadata[]): React.ReactElement {

--- a/packages/pipeline-editor/src/ParameterInputForm.tsx
+++ b/packages/pipeline-editor/src/ParameterInputForm.tsx
@@ -20,10 +20,12 @@ const DIALOG_WIDTH = 27;
 export interface IParameterProps {
   parameters?: {
     name: string;
-    default_value?: {
-      type: 'String' | 'Integer' | 'Float' | 'Bool';
-      value: any;
-    };
+    default_value?:
+      | { type: 'String'; value: string }
+      | { type: 'Integer'; value: number }
+      | { type: 'Float'; value: number }
+      | { type: 'Bool'; value: boolean };
+
     type?: string;
     required?: boolean;
     description?: string;
@@ -67,7 +69,7 @@ export const ParameterInputForm: React.FC<IParameterProps> = ({
               <input
                 id={`${param.name}-paramInput`}
                 name={`${param.name}-paramInput`}
-                defaultChecked={param.default_value?.value}
+                defaultChecked={param.default_value?.value as boolean}
                 type="checkbox"
               />
               <label htmlFor={`${param.name}-paramInput`}>{`${param.name}${
@@ -109,7 +111,7 @@ export const ParameterInputForm: React.FC<IParameterProps> = ({
               id={`${param.name}-paramInput`}
               name={`${param.name}-paramInput`}
               type={type}
-              placeholder={param.default_value?.value}
+              placeholder={param.default_value?.value as string | undefined}
               data-form-required={required}
             />
             <br />

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -1205,7 +1205,6 @@ const PipelineWrapper: React.FC<IProps> = ({
 
   return (
     <ExtendedThemeProvider theme={theme}>
-      z
       <ToastContainer
         position="bottom-center"
         autoClose={30000}

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -37,24 +37,30 @@ import {
   Dropzone,
   RequestErrors,
   showFormDialog,
-  componentCatalogIcon
+  componentCatalogIcon,
+  GenericObjectType
 } from '@elyra/ui-components';
-import { ILabShell } from '@jupyterlab/application';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 import { Dialog, ReactWidget, showDialog } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
 import {
   DocumentRegistry,
   ABCWidgetFactory,
-  DocumentWidget,
-  Context
+  DocumentWidget
 } from '@jupyterlab/docregistry';
 import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
-import { Contents } from '@jupyterlab/services';
+import { ServiceManager } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import 'carbon-components/css/carbon-components.min.css';
 
 import { toArray } from '@lumino/algorithm';
+import { CommandRegistry } from '@lumino/commands';
+import {
+  PartialJSONArray,
+  PartialJSONObject,
+  ReadonlyPartialJSONObject
+} from '@lumino/coreutils';
 import { IDragEvent } from '@lumino/dragdrop';
 import { Signal } from '@lumino/signaling';
 
@@ -74,6 +80,10 @@ import {
 } from './EmptyPipelineContent';
 import { formDialogWidget } from './formDialogWidget';
 import {
+  IRuntimeComponentNodeType,
+  IRuntimeComponentParameter,
+  IRuntimeComponentsResponse,
+  IRuntimeImage,
   usePalette,
   useRuntimeImages,
   useRuntimesSchema
@@ -83,7 +93,8 @@ import {
   PipelineService,
   RUNTIMES_SCHEMASPACE,
   RUNTIME_IMAGES_SCHEMASPACE,
-  COMPONENT_CATALOGS_SCHEMASPACE
+  COMPONENT_CATALOGS_SCHEMASPACE,
+  IRuntimeSchema
 } from './PipelineService';
 import { PipelineSubmissionDialog } from './PipelineSubmissionDialog';
 import {
@@ -112,7 +123,7 @@ export const commandIDs = {
 
 interface IExtendedThemeProviderProps
   extends React.ComponentProps<typeof ThemeProvider> {
-  children: any;
+  children: React.ReactNode;
 }
 
 //extend ThemeProvider to accept the same props as original but with children prop as one of them.
@@ -123,8 +134,10 @@ const ExtendedThemeProvider: React.FC<IExtendedThemeProviderProps> = ({
   return <ThemeProvider {...props}>{children}</ThemeProvider>;
 };
 
-const getAllPaletteNodes = (palette: any): any[] => {
-  if (palette.categories === undefined) {
+const getAllPaletteNodes = (
+  palette: IRuntimeComponentsResponse | undefined
+): IRuntimeComponentNodeType[] => {
+  if (palette?.categories === undefined) {
     return [];
   }
 
@@ -150,83 +163,95 @@ const isRuntimeTypeAvailable = (data: IRuntimeData, type?: string): boolean => {
 };
 
 const getDisplayName = (
-  runtimesSchema: any,
+  runtimesSchema?: IRuntimeSchema[],
   type?: string
 ): string | undefined => {
   if (!type) {
     return undefined;
   }
-  const schema = runtimesSchema?.find((s: any) => s.runtime_type === type);
+  const schema = runtimesSchema?.find((s) => s.runtime_type === type);
   return schema?.title;
 };
 
-class PipelineEditorWidget extends ReactWidget {
+interface IPipelineEditorWidgetProps {
+  context: DocumentRegistry.Context;
   browserFactory: IDefaultFileBrowser;
-  shell: ILabShell;
-  commands: any;
-  addFileToPipelineSignal: Signal<this, any>;
-  refreshPaletteSignal: Signal<this, any>;
-  context: Context;
-  settings: ISettingRegistry.ISettings;
+  serviceManager: ServiceManager.IManager;
+  shell: JupyterFrontEnd.IShell;
+  commands: CommandRegistry;
+  settings?: ISettingRegistry.ISettings;
+  widgetId?: string;
   defaultRuntimeType: string;
+}
 
-  constructor(options: any) {
+class PipelineEditorWidget extends ReactWidget {
+  addFileToPipelineSignal: Signal<
+    PipelineEditorWidget,
+    ReadonlyPartialJSONObject
+  >;
+  refreshPaletteSignal: Signal<PipelineEditorWidget, ReadonlyPartialJSONObject>;
+
+  constructor(private readonly args: IPipelineEditorWidgetProps) {
     super();
-    this.browserFactory = options.browserFactory;
-    this.shell = options.shell;
-    this.commands = options.commands;
-    this.addFileToPipelineSignal = options.addFileToPipelineSignal;
-    this.refreshPaletteSignal = options.refreshPaletteSignal;
-    this.context = options.context;
-    this.settings = options.settings;
-    this.defaultRuntimeType = options.defaultRuntimeType;
-    let nullPipeline = this.context.model.toJSON() === null;
+    let nullPipeline = this.args.context.model.toJSON() === null;
 
-    this.context.model.contentChanged.connect(() => {
+    this.addFileToPipelineSignal = new Signal<
+      PipelineEditorWidget,
+      ReadonlyPartialJSONObject
+    >(this);
+
+    this.refreshPaletteSignal = new Signal<
+      PipelineEditorWidget,
+      ReadonlyPartialJSONObject
+    >(this);
+
+    this.args.context.model.contentChanged.connect(() => {
       if (nullPipeline) {
         nullPipeline = false;
         this.update();
       }
     });
-    this.context.fileChanged.connect(() => {
-      if (this.context.model.toJSON() === null) {
-        const pipelineJson = getEmptyPipelineJson(this.defaultRuntimeType);
-        this.context.model.fromString(JSON.stringify(pipelineJson));
+    this.args.context.fileChanged.connect(() => {
+      if (this.args.context.model.toJSON() === null) {
+        const pipelineJson = getEmptyPipelineJson(this.args.defaultRuntimeType);
+        this.args.context.model.fromString(JSON.stringify(pipelineJson));
       }
     });
   }
 
-  render(): any {
-    if (this.context.model.toJSON() === null) {
+  render() {
+    if (this.args.context.model.toJSON() === null) {
       return <div className="elyra-loader"></div>;
     }
     return (
       <PipelineWrapper
-        context={this.context}
-        browserFactory={this.browserFactory}
-        shell={this.shell}
-        commands={this.commands}
+        context={this.args.context}
+        browserFactory={this.args.browserFactory}
+        shell={this.args.shell}
+        commands={this.args.commands}
         addFileToPipelineSignal={this.addFileToPipelineSignal}
         refreshPaletteSignal={this.refreshPaletteSignal}
         widgetId={this.parent?.id}
-        settings={this.settings}
+        settings={this.args.settings}
+        defaultRuntimeType={this.args.defaultRuntimeType}
+        serviceManager={this.args.serviceManager}
       />
     );
   }
 }
 
-interface IProps {
-  context: DocumentRegistry.Context;
-  browserFactory: IDefaultFileBrowser;
-  shell: ILabShell;
-  commands: any;
-  addFileToPipelineSignal: Signal<PipelineEditorWidget, any>;
-  refreshPaletteSignal: Signal<PipelineEditorWidget, any>;
-  settings?: ISettingRegistry.ISettings;
-  widgetId?: string;
-}
-
-const PipelineWrapper: React.FC<IProps> = ({
+const PipelineWrapper: React.FC<
+  IPipelineEditorWidgetProps & {
+    addFileToPipelineSignal: Signal<
+      PipelineEditorWidget,
+      ReadonlyPartialJSONObject
+    >;
+    refreshPaletteSignal: Signal<
+      PipelineEditorWidget,
+      ReadonlyPartialJSONObject
+    >;
+  }
+> = ({
   context,
   browserFactory,
   shell,
@@ -236,9 +261,12 @@ const PipelineWrapper: React.FC<IProps> = ({
   settings,
   widgetId
 }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- PipelineEditor API not typed
   const ref = useRef<any>(null);
   const [loading, setLoading] = useState(true);
-  const [pipeline, setPipeline] = useState<any>(context.model.toJSON());
+  const [pipeline, setPipeline] = useState<GenericObjectType>(
+    context.model.toJSON() as GenericObjectType
+  );
   const [panelOpen, setPanelOpen] = React.useState(false);
 
   const type: string | undefined =
@@ -278,7 +306,7 @@ const PipelineWrapper: React.FC<IProps> = ({
         metadata: {
           image_name: imageName
         }
-      };
+      } as IRuntimeImage;
     });
   }, [pipeline]);
 
@@ -290,7 +318,7 @@ const PipelineWrapper: React.FC<IProps> = ({
 
   useEffect(() => {
     const handleMutateSignal = (): void => {
-      mutatePalette();
+      mutatePalette?.();
     };
     refreshPaletteSignal.connect(handleMutateSignal);
     return (): void => {
@@ -308,22 +336,25 @@ const PipelineWrapper: React.FC<IProps> = ({
 
   useEffect(() => {
     if (paletteError) {
-      RequestErrors.serverError(paletteError);
-      shell.currentWidget?.close();
+      RequestErrors.serverError(paletteError).then(() => {
+        shell.currentWidget?.close();
+      });
     }
   }, [paletteError, shell.currentWidget]);
 
   useEffect(() => {
     if (runtimeImagesError) {
-      RequestErrors.serverError(runtimeImagesError);
-      shell.currentWidget?.close();
+      RequestErrors.serverError(runtimeImagesError).then(() => {
+        shell.currentWidget?.close();
+      });
     }
   }, [runtimeImagesError, shell.currentWidget]);
 
   useEffect(() => {
     if (runtimesSchemaError) {
-      RequestErrors.serverError(runtimesSchemaError);
-      shell.currentWidget?.close();
+      RequestErrors.serverError(runtimesSchemaError).then(() => {
+        shell.currentWidget?.close();
+      });
     }
   }, [runtimesSchemaError, shell.currentWidget]);
 
@@ -332,7 +363,7 @@ const PipelineWrapper: React.FC<IProps> = ({
     const currentContext = contextRef.current;
 
     const changeHandler = (): void => {
-      const pipelineJson: any = currentContext.model.toJSON();
+      const pipelineJson = currentContext.model.toJSON() as GenericObjectType;
 
       // map IDs to display names
       const nodes = pipelineJson?.pipelines?.[0]?.nodes;
@@ -375,8 +406,14 @@ const PipelineWrapper: React.FC<IProps> = ({
     };
   }, [runtimeDisplayName]);
 
-  const onChange = useCallback((pipelineJson: any): void => {
-    const removeNullValues = (data: any, removeEmptyString?: boolean): void => {
+  const onChange = useCallback((pipelineJson: GenericObjectType): void => {
+    const removeNullValues = (
+      data?: PartialJSONObject,
+      removeEmptyString?: boolean
+    ): void => {
+      if (!data) {
+        return;
+      }
       for (const key in data) {
         if (
           data[key] === null ||
@@ -386,13 +423,13 @@ const PipelineWrapper: React.FC<IProps> = ({
           delete data[key];
         } else if (Array.isArray(data[key])) {
           const newArray = [];
-          for (const i in data[key]) {
-            const item = data[key][i];
+          for (const i in data[key] as PartialJSONArray) {
+            const item = (data[key] as PartialJSONArray)[i];
             if (item === undefined || item === null || item === '') {
               continue;
             }
             if (typeof item === 'object') {
-              removeNullValues(item, true);
+              removeNullValues(item as PartialJSONObject, true);
               if (Object.keys(item).length > 0) {
                 newArray.push(item);
               }
@@ -402,7 +439,7 @@ const PipelineWrapper: React.FC<IProps> = ({
           }
           data[key] = newArray;
         } else if (typeof data[key] === 'object') {
-          removeNullValues(data[key]);
+          removeNullValues(data[key] as PartialJSONObject);
         }
       }
     };
@@ -453,7 +490,8 @@ const PipelineWrapper: React.FC<IProps> = ({
           if (result.button.accept) {
             // proceed with migration
             console.log('migrating pipeline');
-            const pipelineJSON: any = contextRef.current.model.toJSON();
+            const pipelineJSON =
+              contextRef.current.model.toJSON() as GenericObjectType;
             try {
               const migratedPipeline = migrate(pipelineJSON, (pipeline) => {
                 // function for updating to relative paths in v2
@@ -523,7 +561,11 @@ const PipelineWrapper: React.FC<IProps> = ({
     [shell.currentWidget]
   );
 
-  const onFileRequested = async (args: any): Promise<string[] | undefined> => {
+  const onFileRequested = async (args: {
+    filename?: string;
+    propertyID?: string;
+    filters?: { [key: string]: string[] };
+  }): Promise<string[] | undefined> => {
     const pipelineFilePath = contextRef.current.path;
     const contextFilePath = args.filename
       ? PipelineService.getWorkspaceRelativeNodePath(
@@ -534,32 +576,34 @@ const PipelineWrapper: React.FC<IProps> = ({
     const contextFolderPath = PathExt.dirname(contextFilePath);
 
     if (args.propertyID?.includes('dependencies')) {
-      const res = await showBrowseFileDialog(browserFactory.model.manager, {
+      const res = await showBrowseFileDialog({
+        manager: browserFactory.model.manager,
         multiselect: true,
         includeDir: true,
         rootPath: contextFolderPath,
-        filter: (model: any): boolean => {
-          return model.path !== pipelineFilePath;
+        filter: (model) => {
+          return model.path !== pipelineFilePath ? {} : null;
         }
       });
 
-      if (res.button.accept && res.value.length) {
+      if (res.button.accept && res.value?.length) {
         return res.value;
       }
     } else {
-      const res = await showBrowseFileDialog(browserFactory.model.manager, {
+      const res = await showBrowseFileDialog({
+        manager: browserFactory.model.manager,
         startPath: contextFolderPath,
-        filter: (model: Contents.IModel): boolean => {
+        filter: (model) => {
           if (args.filters?.File === undefined || model.type === 'directory') {
-            return true;
+            return {};
           }
 
           const ext = PathExt.extname(model.path);
-          return args.filters.File.includes(ext);
+          return args.filters.File.includes(ext) ? {} : null;
         }
       });
 
-      if (res.button.accept && res.value.length) {
+      if (res.button.accept && res.value?.length) {
         const file = PipelineService.getPipelineRelativeNodePath(
           contextRef.current.path,
           res.value[0]
@@ -571,7 +615,11 @@ const PipelineWrapper: React.FC<IProps> = ({
     return undefined;
   };
 
-  const onPropertiesUpdateRequested = async (args: any): Promise<any> => {
+  const onPropertiesUpdateRequested = async (args: {
+    component_parameters: IRuntimeComponentParameter;
+  }): Promise<{
+    component_parameters: IRuntimeComponentParameter;
+  }> => {
     if (!contextRef.current.path) {
       return args;
     }
@@ -579,19 +627,18 @@ const PipelineWrapper: React.FC<IProps> = ({
       contextRef.current.path,
       args.component_parameters.filename
     );
-    const new_env_vars = await ContentParser.getEnvVars(path).then(
-      (response: any) =>
-        response.map((str: string) => {
-          return { env_var: str };
-        })
+    const new_env_vars = await ContentParser.getEnvVars(path).then((response) =>
+      response.map((str: string) => {
+        return { env_var: str };
+      })
     );
 
     const env_vars = args.component_parameters?.env_vars ?? [];
     const merged_env_vars = [
       ...env_vars,
       ...new_env_vars.filter(
-        (new_var: any) =>
-          !env_vars.some((old_var: any) => {
+        (new_var) =>
+          !env_vars.some((old_var) => {
             return old_var.env_var === new_var.env_var;
           })
       )
@@ -650,6 +697,9 @@ const PipelineWrapper: React.FC<IProps> = ({
       }
       return PipelineService.getComponentDef(type, componentId)
         .then((res) => {
+          if (!res) {
+            return;
+          }
           const nodeDef = getAllPaletteNodes(palette).find(
             (n) => n.id === componentId
           );
@@ -659,15 +709,15 @@ const PipelineWrapper: React.FC<IProps> = ({
             label: nodeDef?.label ?? componentId
           });
         })
-        .catch((e) => RequestErrors.serverError(e));
+        .catch(async (e) => await RequestErrors.serverError(e));
     },
     [commands, palette, type]
   );
 
-  const onDoubleClick = (data: any): void => {
+  const onDoubleClick = (data: { selectedObjectIds: string[] }): void => {
     for (let i = 0; i < data.selectedObjectIds.length; i++) {
       const node = pipeline.pipelines[0].nodes.find(
-        (node: any) => node.id === data.selectedObjectIds[i]
+        (node: { id: string }) => node.id === data.selectedObjectIds[i]
       );
       const nodeDef = getAllPaletteNodes(palette).find(
         (n) => n.op === node?.op
@@ -679,20 +729,20 @@ const PipelineWrapper: React.FC<IProps> = ({
             node.app_data.component_parameters.filename
           )
         });
-      } else if (!nodeDef?.app_data?.parameter_refs?.['filehandler']) {
-        handleOpenComponentDef(nodeDef?.id, node?.app_data?.component_source);
+      } else if (nodeDef && !nodeDef.app_data?.parameter_refs?.filehandler) {
+        handleOpenComponentDef(nodeDef.id, node?.app_data?.component_source);
       }
     }
   };
 
   const handleSubmission = useCallback(
     async (actionType: 'run' | 'export'): Promise<void> => {
-      const pipelineJson: any = context.model.toJSON();
+      const pipelineJson = context.model.toJSON() as GenericObjectType;
       // Check that all nodes are valid
       const errorMessages = validate(
         JSON.stringify(pipelineJson),
         getAllPaletteNodes(palette),
-        palette.properties
+        palette?.properties
       );
       if (errorMessages && errorMessages.length > 0) {
         let errorMessage = '';
@@ -729,19 +779,31 @@ const PipelineWrapper: React.FC<IProps> = ({
       const runtimeTypes = await PipelineService.getRuntimeTypes();
       const runtimes = await PipelineService.getRuntimes()
         .then((runtimeList) => {
-          return runtimeList.filter((runtime: any) => {
+          return runtimeList?.filter((runtime) => {
             return (
               !runtime.metadata.runtime_enabled &&
-              !!runtimeTypes.find(
-                (r: any) => runtime.metadata.runtime_type === r.id
-              )
+              !!runtimeTypes.find((r) => runtime.metadata.runtime_type === r.id)
             );
           });
         })
-        .catch((error) => RequestErrors.serverError(error));
-      const schema = await PipelineService.getRuntimesSchema().catch((error) =>
-        RequestErrors.serverError(error)
+        .catch(async (error) => {
+          await RequestErrors.serverError(error);
+        });
+      const schema = await PipelineService.getRuntimesSchema().catch(
+        async (error) => {
+          await RequestErrors.serverError(error);
+        }
       );
+
+      if (!runtimes) {
+        await RequestErrors.noMetadataError('runtime');
+        return;
+      }
+
+      if (!schema) {
+        await RequestErrors.noMetadataError('schema');
+        return;
+      }
 
       const runtimeData = createRuntimeData({
         schema,
@@ -772,24 +834,33 @@ const PipelineWrapper: React.FC<IProps> = ({
       // Capitalize
       title = title.charAt(0).toUpperCase() + title.slice(1);
 
-      let dialogOptions: Partial<Dialog.IOptions<any>>;
+      let dialogOptions: Partial<Dialog.IOptions<GenericObjectType>>;
 
       pipelineJson.pipelines[0].app_data.properties.pipeline_parameters =
         pipelineJson.pipelines[0].app_data.properties.pipeline_parameters?.filter(
-          (param: any) => {
-            return !!pipelineJson.pipelines[0].nodes.find((node: any) => {
-              return (
-                param.name !== '' &&
-                (node.app_data.component_parameters?.pipeline_parameters?.includes(
-                  param.name
-                ) ||
-                  Object.values(node.app_data.component_parameters ?? {}).find(
-                    (property: any) =>
-                      property.widget === 'parameter' &&
-                      property.value === param.name
-                  ))
-              );
-            });
+          (param: { name: string }) => {
+            return !!pipelineJson.pipelines[0].nodes.find(
+              (node: {
+                app_data: {
+                  component_parameters?: {
+                    pipeline_parameters?: GenericObjectType;
+                  };
+                };
+              }) => {
+                return (
+                  param.name !== '' &&
+                  (node.app_data.component_parameters?.pipeline_parameters?.includes(
+                    param.name
+                  ) ||
+                    (node.app_data.component_parameters &&
+                      Object.values(node.app_data.component_parameters).find(
+                        (property) =>
+                          property.widget === 'parameter' &&
+                          property.value === param.name
+                      )))
+                );
+              }
+            );
           }
         );
 
@@ -915,7 +986,9 @@ const PipelineWrapper: React.FC<IProps> = ({
           PipelineService.submitPipeline(
             pipelineJson,
             configDetails?.platform.displayName ?? ''
-          ).catch((error) => RequestErrors.serverError(error));
+          ).catch(async (error) => {
+            await RequestErrors.serverError(error);
+          });
           break;
         case 'export':
           PipelineService.exportPipeline(
@@ -923,14 +996,16 @@ const PipelineWrapper: React.FC<IProps> = ({
             exportType,
             exportPath,
             dialogResult.value.overwrite
-          ).catch((error) => RequestErrors.serverError(error));
+          ).catch(async (error) => {
+            await RequestErrors.serverError(error);
+          });
           break;
       }
     },
     [context.model, palette, runtimeDisplayName, type, shell]
   );
 
-  const handleClearPipeline = useCallback(async (data: any): Promise<any> => {
+  const handleClearPipeline = useCallback(async (): Promise<void> => {
     return showDialog({
       title: 'Clear Pipeline',
       body: 'Are you sure you want to clear the pipeline?',
@@ -941,7 +1016,8 @@ const PipelineWrapper: React.FC<IProps> = ({
       ]
     }).then((result) => {
       if (result.button.accept) {
-        const newPipeline: any = contextRef.current.model.toJSON();
+        const newPipeline =
+          contextRef.current.model.toJSON() as GenericObjectType;
         if (newPipeline?.pipelines?.[0]?.nodes?.length > 0) {
           newPipeline.pipelines[0].nodes = [];
         }
@@ -965,7 +1041,7 @@ const PipelineWrapper: React.FC<IProps> = ({
   }, []);
 
   const onAction = useCallback(
-    (args: { type: string; payload?: any }) => {
+    (args: { type: string; payload?: GenericObjectType | string }) => {
       switch (args.type) {
         case 'save':
           contextRef.current.save();
@@ -975,7 +1051,7 @@ const PipelineWrapper: React.FC<IProps> = ({
           handleSubmission(args.type);
           break;
         case 'clear':
-          handleClearPipeline(args.payload);
+          handleClearPipeline();
           break;
         case 'toggleOpenPanel':
           setPanelOpen(!panelOpen);
@@ -995,6 +1071,9 @@ const PipelineWrapper: React.FC<IProps> = ({
           );
           break;
         case 'openFile':
+          if (typeof args.payload !== 'string') {
+            return;
+          }
           commands.execute(commandIDs.openDocManager, {
             path: PipelineService.getWorkspaceRelativeNodePath(
               contextRef.current.path,
@@ -1003,6 +1082,9 @@ const PipelineWrapper: React.FC<IProps> = ({
           });
           break;
         case 'openComponentDef':
+          if (!args.payload || typeof args.payload !== 'object') {
+            return;
+          }
           handleOpenComponentDef(
             args.payload.componentId,
             args.payload.componentSource
@@ -1131,6 +1213,7 @@ const PipelineWrapper: React.FC<IProps> = ({
         };
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- PipelineEditor API not typed
       toArray(fileBrowser.selectedItems()).map((item: any): void => {
         if (PipelineService.isSupportedNode(item)) {
           item.op = PipelineService.getNodeType(item.path);
@@ -1248,39 +1331,59 @@ const PipelineWrapper: React.FC<IProps> = ({
 
 export class PipelineEditorFactory extends ABCWidgetFactory<DocumentWidget> {
   browserFactory: IDefaultFileBrowser;
-  shell: ILabShell;
-  commands: any;
-  addFileToPipelineSignal: Signal<this, any>;
-  refreshPaletteSignal: Signal<this, any>;
-  settings: ISettingRegistry.ISettings;
+  shell: JupyterFrontEnd.IShell;
+  commands: CommandRegistry;
+  serviceManager: ServiceManager.IManager;
+  settings: ISettingRegistry.ISettings | undefined;
   defaultRuntimeType: string;
+  content?: PipelineEditorWidget;
 
-  constructor(options: any) {
+  constructor(
+    options: Pick<
+      IPipelineEditorWidgetProps,
+      | 'shell'
+      | 'commands'
+      | 'browserFactory'
+      | 'serviceManager'
+      | 'settings'
+      | 'defaultRuntimeType'
+    > &
+      Pick<
+        DocumentRegistry.IWidgetFactoryOptions<DocumentWidget>,
+        'name' | 'fileTypes' | 'defaultFor'
+      >
+  ) {
     super(options);
     this.browserFactory = options.browserFactory;
     this.shell = options.shell;
     this.commands = options.commands;
-    this.addFileToPipelineSignal = new Signal<this, any>(this);
-    this.refreshPaletteSignal = new Signal<this, any>(this);
     this.settings = options.settings;
+    this.serviceManager = options.serviceManager;
     this.defaultRuntimeType = options.defaultRuntimeType;
+  }
+
+  get addFileToPipelineSignal() {
+    return this.content?.addFileToPipelineSignal;
+  }
+
+  get refreshPaletteSignal() {
+    return this.content?.refreshPaletteSignal;
   }
 
   protected createNewWidget(context: DocumentRegistry.Context): DocumentWidget {
     // Creates a blank widget with a DocumentWidget wrapper
-    const props = {
+    const props: IPipelineEditorWidgetProps = {
       shell: this.shell,
       commands: this.commands,
       browserFactory: this.browserFactory,
       context: context,
-      addFileToPipelineSignal: this.addFileToPipelineSignal,
-      refreshPaletteSignal: this.refreshPaletteSignal,
       settings: this.settings,
-      defaultRuntimeType: this.defaultRuntimeType
+      defaultRuntimeType: this.defaultRuntimeType,
+      serviceManager: this.serviceManager
     };
-    const content = new PipelineEditorWidget(props);
+    this.content = new PipelineEditorWidget(props);
 
-    const widget = new DocumentWidget({ content, context });
+    const widget = new DocumentWidget({ content: this.content, context });
     widget.addClass(PIPELINE_CLASS);
     widget.title.icon = pipelineIcon;
     return widget;

--- a/packages/pipeline-editor/src/PipelineService.tsx
+++ b/packages/pipeline-editor/src/PipelineService.tsx
@@ -14,31 +14,53 @@
  * limitations under the License.
  */
 
-import { MetadataService, IDictionary, RequestHandler } from '@elyra/services';
-import { RequestErrors } from '@elyra/ui-components';
+import {
+  IDictionary,
+  IElyraResource,
+  IMetadataResource,
+  ISchemaResource,
+  MetadataService,
+  RequestHandler
+} from '@elyra/services';
+import { GenericObjectType, RequestErrors } from '@elyra/ui-components';
 
-import { showDialog, Dialog } from '@jupyterlab/apputils';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
 
 import * as React from 'react';
+
+import { IRuntimeComponentNodeType } from './pipeline-hooks';
 
 export const KFP_SCHEMA = 'kfp';
 export const RUNTIMES_SCHEMASPACE = 'runtimes';
 export const RUNTIME_IMAGES_SCHEMASPACE = 'runtime-images';
 export const COMPONENT_CATALOGS_SCHEMASPACE = 'component-catalogs';
 
-export interface IRuntime {
-  name: string;
-  display_name: string;
-  schema_name: string;
-  metadata: {
-    runtime_type: string;
-  };
+export interface IPipelineExportBody {
+  pipeline: IPipelineResource;
+  export_format: string;
+  export_path: string;
+  overwrite: boolean;
 }
 
-export interface ISchema {
-  name: string;
-  title: string;
+export interface IPipelineResource extends IElyraResource {
+  primary_pipeline: string;
+  pipelines: Array<{
+    id: string;
+    name?: string;
+    nodes?: Array<IDictionary<unknown>>;
+    runtime?: string;
+    runtime_config?: IDictionary<unknown>;
+  }>;
+}
+
+export interface IPipelineScheduleResponse {
+  run_url: string;
+  object_storage_url: string;
+  object_storage_path: string;
+}
+
+export interface IRuntimeSchema extends ISchemaResource {
   runtime_type: string;
 }
 
@@ -60,7 +82,7 @@ const CONTENT_TYPE_MAPPER: Map<string, ContentType> = new Map([
   ['.r', ContentType.r]
 ]);
 
-export interface IRuntimeType {
+export interface IRuntimeType extends IElyraResource {
   runtime_enabled: boolean;
   id: string;
   display_name: string;
@@ -68,15 +90,22 @@ export interface IRuntimeType {
   export_file_types: { id: string; display_name: string }[];
 }
 
+export interface IRuntimesTypesResponse extends IElyraResource {
+  runtime_types: IRuntimeType[];
+}
+
 export class PipelineService {
   /**
    * Returns a list of resources corresponding to each active runtime-type.
    */
   static async getRuntimeTypes(): Promise<IRuntimeType[]> {
-    const res = await RequestHandler.makeGetRequest(
+    const res = await RequestHandler.makeGetRequest<IRuntimesTypesResponse>(
       'elyra/pipeline/runtimes/types'
     );
-    return res.runtime_types.sort((a: any, b: any) => a.id.localeCompare(b.id));
+    if (!res) {
+      return [];
+    }
+    return res.runtime_types.sort((a, b) => a.id.localeCompare(b.id));
   }
 
   /**
@@ -84,20 +113,20 @@ export class PipelineService {
    * `runtimes metadata`. This is used to submit the pipeline to be
    * executed on these runtimes.
    */
-  static async getRuntimes(): Promise<any> {
+  static async getRuntimes(): Promise<IMetadataResource[] | undefined> {
     return MetadataService.getMetadata(RUNTIMES_SCHEMASPACE);
   }
 
   /**
    * Returns a list of runtime schema
    */
-  static async getRuntimesSchema(showError = true): Promise<any> {
+  static async getRuntimesSchema(): Promise<IRuntimeSchema[] | undefined> {
     return MetadataService.getSchema(RUNTIMES_SCHEMASPACE).then((schema) => {
-      if (showError && Object.keys(schema).length === 0) {
-        return RequestErrors.noMetadataError('schema');
+      if (!schema) {
+        return;
       }
 
-      return schema;
+      return schema as IRuntimeSchema[];
     });
   }
 
@@ -105,34 +134,37 @@ export class PipelineService {
    * Return a list of configured container images that are used as runtimes environments
    * to run the pipeline nodes.
    */
-  static async getRuntimeImages(): Promise<any> {
+  static async getRuntimeImages(): Promise<IDictionary<string> | undefined> {
     try {
       let runtimeImages = await MetadataService.getMetadata('runtime-images');
 
-      runtimeImages = runtimeImages.sort(
-        (a: any, b: any) => 0 - (a.name > b.name ? -1 : 1)
-      );
-
-      if (Object.keys(runtimeImages).length === 0) {
-        return RequestErrors.noMetadataError('runtime image');
+      if (!runtimeImages?.length) {
+        await RequestErrors.noMetadataError('runtime image');
+        return;
       }
+
+      runtimeImages = runtimeImages?.sort(
+        (a, b) => 0 - (a.name > b.name ? -1 : 1)
+      );
 
       const images: IDictionary<string> = {};
       for (const image in runtimeImages) {
-        const imageName: string =
-          runtimeImages[image]['metadata']['image_name'];
-        images[imageName] = runtimeImages[image]['display_name'];
+        const imageName = (
+          runtimeImages[image].metadata as { image_name: string }
+        ).image_name;
+        images[imageName] = runtimeImages[image].display_name;
       }
       return images;
     } catch (error) {
       Promise.reject(error);
+      return;
     }
   }
 
   static async getComponentDef(
     type = 'local',
     componentID: string
-  ): Promise<IComponentDef> {
+  ): Promise<IComponentDef | undefined> {
     return await RequestHandler.makeGetRequest<IComponentDef>(
       `elyra/pipeline/components/${type}/${componentID}`
     );
@@ -157,7 +189,7 @@ export class PipelineService {
   static getWaitDialog(
     title = 'Making server request...',
     body = 'This may take some time'
-  ): Dialog<any> {
+  ): Dialog<void> {
     return new Dialog({
       title: title,
       body: body,
@@ -172,14 +204,17 @@ export class PipelineService {
    * @param runtimeName
    */
   static async submitPipeline(
-    pipeline: any,
+    pipeline: GenericObjectType,
     runtimeName: string
-  ): Promise<any> {
-    return RequestHandler.makePostRequest(
+  ): Promise<void> {
+    return RequestHandler.makePostRequest<IPipelineScheduleResponse>(
       'elyra/pipeline/schedule',
       JSON.stringify(pipeline),
       this.getWaitDialog('Packaging and submitting pipeline ...')
-    ).then((response) => {
+    ).then(async (response) => {
+      if (!response) {
+        return;
+      }
       let dialogTitle;
       let dialogBody;
       if (response['run_url']) {
@@ -187,19 +222,6 @@ export class PipelineService {
         dialogTitle = 'Job submission to ' + runtimeName + ' succeeded';
         dialogBody = (
           <p>
-            {response['platform'] === 'APACHE_AIRFLOW' ? (
-              <p>
-                Apache Airflow DAG has been pushed to the{' '}
-                <a
-                  href={response['git_url']}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Git repository.
-                </a>
-                <br />
-              </p>
-            ) : null}
             Check the status of your job at{' '}
             <a
               href={response['run_url']}
@@ -233,7 +255,7 @@ export class PipelineService {
         );
       }
 
-      return showDialog({
+      await showDialog({
         title: dialogTitle,
         body: dialogBody,
         buttons: [Dialog.okButton()]
@@ -251,11 +273,11 @@ export class PipelineService {
    * @param overwrite
    */
   static async exportPipeline(
-    pipeline: any,
+    pipeline: GenericObjectType,
     pipeline_export_format: string,
     pipeline_export_path: string,
     overwrite: boolean
-  ): Promise<any> {
+  ): Promise<void> {
     console.log(
       'Exporting pipeline to [' + pipeline_export_format + '] format'
     );
@@ -269,14 +291,17 @@ export class PipelineService {
       overwrite: overwrite
     };
 
-    return RequestHandler.makePostRequest(
+    return RequestHandler.makePostRequest<IPipelineExportBody>(
       'elyra/pipeline/export',
       JSON.stringify(body),
       this.getWaitDialog('Generating pipeline artifacts ...')
-    ).then((response) => {
-      return showDialog({
+    ).then(async (response) => {
+      if (!response) {
+        return;
+      }
+      await showDialog({
         title: 'Pipeline export succeeded',
-        body: <p>Exported file: {response['export_path']} </p>,
+        body: <p>Exported file: {response.export_path} </p>,
         buttons: [Dialog.okButton()]
       });
     });
@@ -294,7 +319,7 @@ export class PipelineService {
    * Check if a given file is allowed to be added to the pipeline
    * @param item
    */
-  static isSupportedNode(file: any): boolean {
+  static isSupportedNode(file: { path: string }): boolean {
     if (PipelineService.getNodeType(file.path)) {
       return true;
     } else {
@@ -326,16 +351,17 @@ export class PipelineService {
   }
 
   static setNodePathsRelativeToWorkspace(
-    pipeline: any,
-    paletteNodes: any[],
+    pipeline: GenericObjectType,
+    paletteNodes: IRuntimeComponentNodeType[],
     pipelinePath: string
-  ): any {
+  ): GenericObjectType {
     for (const node of pipeline.nodes) {
       const nodeDef = paletteNodes.find((n) => {
         return n.op === node.op;
       });
       const parameters =
-        nodeDef.app_data.properties.properties.component_parameters.properties;
+        nodeDef?.app_data.properties?.properties.component_parameters
+          .properties;
       for (const param in parameters) {
         if (parameters[param].uihints?.['ui:widget'] === 'file') {
           node.app_data.component_parameters[param] =

--- a/packages/pipeline-editor/src/RuntimeImagesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimeImagesWidget.tsx
@@ -17,12 +17,10 @@
 import {
   MetadataWidget,
   IMetadataWidgetProps,
-  IMetadata,
   MetadataDisplay,
   IMetadataDisplayProps
-  //IMetadataDisplayState,
 } from '@elyra/metadata-common';
-import { IDictionary } from '@elyra/services';
+import { IMetadataResource } from '@elyra/services';
 
 import React from 'react';
 
@@ -56,16 +54,17 @@ const getLinkFromImageName = (imageName: string): string => {
  * A React Component for displaying the runtime images list.
  */
 class RuntimeImagesDisplay extends MetadataDisplay<IMetadataDisplayProps> {
-  renderExpandableContent(metadata: IDictionary<any>): JSX.Element {
+  renderExpandableContent(metadata: IMetadataResource): JSX.Element {
+    const imageName = metadata.metadata.image_name as string;
     return (
       <div>
         <h6>Container Image</h6>
         <a
-          href={getLinkFromImageName(metadata.metadata.image_name)}
+          href={getLinkFromImageName(imageName)}
           target="_blank"
           rel="noreferrer noopener"
         >
-          {metadata.metadata.image_name}
+          {imageName}
         </a>
       </div>
     );
@@ -80,7 +79,7 @@ export class RuntimeImagesWidget extends MetadataWidget {
     super(props);
   }
 
-  renderDisplay(metadata: IMetadata[]): React.ReactElement {
+  renderDisplay(metadata: IMetadataResource[]): React.ReactElement {
     if (Array.isArray(metadata) && !metadata.length) {
       // Empty metadata
       return (

--- a/packages/pipeline-editor/src/RuntimesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimesWidget.tsx
@@ -16,12 +16,20 @@
 import {
   MetadataWidget,
   IMetadataWidgetProps,
-  IMetadata,
   MetadataDisplay,
-  IMetadataDisplayProps
+  IMetadataDisplayProps,
+  IOpenMetadataEditorArgs
 } from '@elyra/metadata-common';
-import { IDictionary, MetadataService } from '@elyra/services';
-import { RequestErrors } from '@elyra/ui-components';
+import {
+  IMetadataResource,
+  ISchemaResource,
+  MetadataService
+} from '@elyra/services';
+import {
+  GenericObjectType,
+  IErrorResponse,
+  RequestErrors
+} from '@elyra/ui-components';
 import React from 'react';
 
 import {
@@ -31,6 +39,10 @@ import {
 } from './PipelineService';
 
 const RUNTIMES_METADATA_CLASS = 'elyra-metadata-runtimes';
+
+interface IRuntimeSchema extends ISchemaResource {
+  runtime_type: string;
+}
 
 const addTrailingSlash = (url: string): string => {
   return url.endsWith('/') ? url : url + '/';
@@ -47,13 +59,13 @@ const getGithubURLFromAPI = (apiEndpoint: string): string => {
 };
 
 export interface IRuntimesDisplayProps extends IMetadataDisplayProps {
-  metadata: IMetadata[];
-  openMetadataEditor: (args: any) => void;
+  metadata: IMetadataResource[];
+  openMetadataEditor: (args: IOpenMetadataEditorArgs) => void;
   updateMetadata: () => void;
   schemaspace: string;
   sortMetadata: boolean;
   className: string;
-  schemas?: IDictionary<any>[];
+  schemas?: ISchemaResource[];
   titleContext?: string;
   appendToTitle?: boolean;
 }
@@ -63,22 +75,29 @@ export interface IRuntimesDisplayProps extends IMetadataDisplayProps {
  */
 
 class RuntimesDisplay extends MetadataDisplay<IRuntimesDisplayProps> {
-  renderExpandableContent(metadata: IDictionary<any>): JSX.Element {
-    let apiEndpoint = addTrailingSlash(metadata.metadata.api_endpoint);
-    let cosEndpoint = addTrailingSlash(metadata.metadata.cos_endpoint);
+  renderExpandableContent(metadata: IMetadataResource): JSX.Element {
+    let apiEndpoint = addTrailingSlash(
+      metadata.metadata.api_endpoint as string
+    );
+    let cosEndpoint = addTrailingSlash(
+      metadata.metadata.cos_endpoint as string
+    );
 
     let githubRepoElement = null;
     let metadata_props = null;
 
     for (const schema of this.props.schemas ?? []) {
       if (schema.name === metadata.schema_name) {
-        metadata_props = schema.properties.metadata.properties;
+        const metadata = schema.properties?.metadata as
+          | GenericObjectType
+          | undefined;
+        metadata_props = metadata?.properties;
       }
     }
 
     if (metadata.schema_name === 'airflow' && metadata_props) {
       const githubRepoUrl =
-        getGithubURLFromAPI(metadata.metadata.github_api_endpoint) +
+        getGithubURLFromAPI(metadata.metadata.github_api_endpoint as string) +
         metadata.metadata.github_repo +
         '/tree/' +
         metadata.metadata.github_branch +
@@ -97,13 +116,17 @@ class RuntimesDisplay extends MetadataDisplay<IRuntimesDisplayProps> {
     if (metadata.schema_name === 'kfp') {
       if (metadata.metadata.public_api_endpoint) {
         // user specified a public API endpoint. use it instead of the API endpoint
-        apiEndpoint = addTrailingSlash(metadata.metadata.public_api_endpoint);
+        apiEndpoint = addTrailingSlash(
+          metadata.metadata.public_api_endpoint as string
+        );
       }
     }
 
     if (metadata.metadata.public_cos_endpoint) {
       // user specified a public COS endpoint. use it instead of the API endpoint
-      cosEndpoint = addTrailingSlash(metadata.metadata.public_cos_endpoint);
+      cosEndpoint = addTrailingSlash(
+        metadata.metadata.public_cos_endpoint as string
+      );
     }
 
     return (
@@ -140,22 +163,27 @@ export class RuntimesWidget extends MetadataWidget {
     super(props);
   }
 
-  async fetchMetadata(): Promise<any> {
-    return await PipelineService.getRuntimes().catch((error) =>
-      RequestErrors.serverError(error)
-    );
+  async fetchMetadata(): Promise<IMetadataResource[] | undefined> {
+    return await PipelineService.getRuntimes().catch(async (error) => {
+      await RequestErrors.serverError(error);
+      return [];
+    });
   }
 
   async getSchemas(): Promise<void> {
     try {
       const schemas = await MetadataService.getSchema(this.props.schemaspace);
+      if (!schemas) {
+        return;
+      }
       this.runtimeTypes = await PipelineService.getRuntimeTypes();
-      const sortedSchema = schemas.sort((a: any, b: any) =>
-        a.title.localeCompare(b.title)
+      const sortedSchema = schemas.sort((a, b) =>
+        (a.title ?? '').localeCompare(b.title ?? '')
       );
-      this.schemas = sortedSchema.filter((schema: any) => {
+      this.schemas = sortedSchema.filter((schema) => {
+        const runtimeSchema = schema as IRuntimeSchema;
         return !!this.runtimeTypes.find(
-          (r) => r.id === schema.runtime_type && r.runtime_enabled
+          (r) => r.id === runtimeSchema.runtime_type && r.runtime_enabled
         );
       });
       if (this.schemas?.length ?? 0 > 1) {
@@ -170,21 +198,21 @@ export class RuntimesWidget extends MetadataWidget {
               title: schema.title,
               titleContext: this.props.titleContext,
               appendToTitle: this.props.appendToTitle
-            } as any
+            } as GenericObjectType
           });
         }
       }
       this.update();
     } catch (error) {
-      RequestErrors.serverError(error);
+      await RequestErrors.serverError(error as IErrorResponse);
     }
   }
 
-  private getSchemaTitle = (metadata: IMetadata): string => {
+  private getSchemaTitle = (metadata: IMetadataResource): string => {
     if (this.schemas) {
       for (const schema of this.schemas) {
         if (schema.name === metadata.schema_name) {
-          return schema.title;
+          return schema.title ?? '';
         }
       }
     }
@@ -201,7 +229,7 @@ export class RuntimesWidget extends MetadataWidget {
     });
   }
 
-  renderDisplay(metadata: IMetadata[]): React.ReactElement {
+  renderDisplay(metadata: IMetadataResource[]): React.ReactElement {
     if (Array.isArray(metadata) && !metadata.length) {
       // Empty metadata
       return (

--- a/packages/pipeline-editor/src/RuntimesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimesWidget.tsx
@@ -19,7 +19,6 @@ import {
   IMetadata,
   MetadataDisplay,
   IMetadataDisplayProps
-  //IMetadataDisplayState,
 } from '@elyra/metadata-common';
 import { IDictionary, MetadataService } from '@elyra/services';
 import { RequestErrors } from '@elyra/ui-components';

--- a/packages/pipeline-editor/src/dialogs.tsx
+++ b/packages/pipeline-editor/src/dialogs.tsx
@@ -17,7 +17,7 @@
 import { Dialog } from '@jupyterlab/apputils';
 import React from 'react';
 
-export const unknownError = (message: string): any => ({
+export const unknownError = (message: string) => ({
   title: 'Load pipeline failed!',
   body: message,
   buttons: [Dialog.okButton()]

--- a/packages/pipeline-editor/src/formDialogWidget.ts
+++ b/packages/pipeline-editor/src/formDialogWidget.ts
@@ -14,22 +14,25 @@
  * limitations under the License.
  */
 
+import { GenericObjectType } from '@elyra/ui-components';
 import { ReactWidget, Dialog } from '@jupyterlab/apputils';
 import { MessageLoop } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 
 export const formDialogWidget = (
   dialogComponent: JSX.Element
-): Dialog.IBodyWidget<any> => {
-  const widget = ReactWidget.create(dialogComponent) as Dialog.IBodyWidget<any>;
+): Dialog.IBodyWidget<GenericObjectType> => {
+  const widget = ReactWidget.create(
+    dialogComponent
+  ) as Dialog.IBodyWidget<GenericObjectType>;
 
   // Immediately update the body even though it has not yet attached in
   // order to trigger a render of the DOM nodes from the React element.
   MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
 
-  widget.getValue = (): any => {
+  widget.getValue = (): GenericObjectType => {
     const form = widget.node.querySelector('form');
-    const formValues: { [key: string]: any } = {};
+    const formValues: GenericObjectType = {};
     for (const element of Object.values(
       form?.elements ?? []
     ) as HTMLInputElement[]) {

--- a/packages/pipeline-editor/src/pipeline-hooks.ts
+++ b/packages/pipeline-editor/src/pipeline-hooks.ts
@@ -14,34 +14,41 @@
  * limitations under the License.
  */
 
-import { MetadataService, RequestHandler } from '@elyra/services';
+import {
+  IMetadataResource,
+  MetadataService,
+  RequestHandler
+} from '@elyra/services';
+import { GenericObjectType } from '@elyra/ui-components';
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
 import produce from 'immer';
-import useSWR from 'swr';
+import useSWR, { SWRResponse } from 'swr';
 
-import { PipelineService } from './PipelineService';
+import { IRuntimeSchema, PipelineService } from './PipelineService';
 
 export const GENERIC_CATEGORY_ID = 'Elyra';
 
 interface IReturn<T> {
   data?: T | undefined;
-  error?: any;
-  mutate?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SWR API
+  error?: SWRResponse<T, any>['error'];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SWR API
+  mutate?: SWRResponse<T, any>['mutate'];
 }
 
 type IRuntimeImagesResponse = IRuntimeImage[];
 
-interface IRuntimeImage {
-  name: string;
-  display_name: string;
+export interface IRuntimeImage extends IMetadataResource {
   metadata: {
     image_name: string;
   };
 }
 
-const metadataFetcher = async <T>(key: string): Promise<T> => {
-  return await MetadataService.getMetadata(key);
+const metadataFetcher = async <T extends IMetadataResource[]>(
+  key: string
+): Promise<T> => {
+  return (await MetadataService.getMetadata(key)) as T;
 };
 
 export const useRuntimeImages = (
@@ -99,21 +106,62 @@ export const useRuntimeImages = (
 };
 
 const schemaFetcher = async <T>(key: string): Promise<T> => {
-  return await MetadataService.getSchema(key);
+  return (await MetadataService.getSchema(key)) as T;
 };
 
-// TODO: type this
-export const useRuntimesSchema = (): IReturn<any> => {
-  const { data, error } = useSWR<any>('runtimes', schemaFetcher);
+export const useRuntimesSchema = (): IReturn<IRuntimeSchema[]> => {
+  const { data, error } = useSWR<IRuntimeSchema[]>('runtimes', schemaFetcher);
 
   return { data, error };
 };
 
-interface IRuntimeComponentsResponse {
+export interface IRuntimeComponentsResponse {
   version: string;
   categories: IRuntimeComponent[];
   properties: IComponentPropertiesResponse;
   parameters: IComponentPropertiesResponse;
+}
+
+// Types come from `elyra/templates/components/canvas_palette_template.jinja2`
+// Example: `elyra/tests/pipeline/resources/palette.json`
+
+export interface IRuntimeComponentInputOutputData {
+  id: string;
+  app_data: {
+    ui_data: {
+      label: string;
+      cardinality: {
+        min: number;
+        max: number;
+      };
+    };
+  };
+}
+
+export interface IRuntimeComponentParameter {
+  filename: string;
+  env_vars?: { env_var: string }[];
+}
+
+export interface IRuntimeComponentNodeType {
+  op: string;
+  id: string;
+  label: string;
+  image: string;
+  runtime_type?: string;
+  type: 'execution_node';
+  inputs: { app_data: IRuntimeComponentInputOutputData }[];
+  outputs: { app_data: IRuntimeComponentInputOutputData }[];
+  app_data: {
+    parameter_refs?: {
+      filehandler: string;
+    };
+    properties?: IComponentPropertiesResponse;
+    image: string;
+    ui_data: {
+      image: string;
+    };
+  };
 }
 
 export interface IRuntimeComponent {
@@ -122,22 +170,13 @@ export interface IRuntimeComponent {
   id: string;
   description: string;
   runtime?: string;
-  node_types: {
-    op: string;
-    id: string;
-    label: string;
-    image: string;
-    runtime_type?: string;
-    type: 'execution_node';
-    inputs: { app_data: any }[];
-    outputs: { app_data: any }[];
-    app_data: any;
-  }[];
+  node_types: IRuntimeComponentNodeType[];
   extensions?: string[];
 }
 
 interface IComponentPropertiesResponse {
-  current_parameters: { [key: string]: any };
+  current_parameters: GenericObjectType;
+  properties: GenericObjectType;
   parameters: { id: string }[];
   uihints: {
     parameter_info: {
@@ -149,7 +188,7 @@ interface IComponentPropertiesResponse {
         default: string;
         placement: 'on_panel';
       };
-      data: any;
+      data: GenericObjectType;
     }[];
   };
   group_info: {
@@ -196,8 +235,9 @@ const NodeIcons: Map<string, string> = new Map([
 ]);
 
 // TODO: We should decouple components and properties to support lazy loading.
-// TODO: type this
-export const componentFetcher = async (type: string): Promise<any> => {
+export const componentFetcher = async (
+  type: string
+): Promise<IRuntimeComponentsResponse> => {
   const palettePromise =
     RequestHandler.makeGetRequest<IRuntimeComponentsResponse>(
       `elyra/pipeline/components/${type}`
@@ -223,8 +263,15 @@ export const componentFetcher = async (type: string): Promise<any> => {
       typesPromise
     ]);
 
+  if (!palette || !pipelineProperties || !types) {
+    throw new Error('Failed to fetch palette data');
+  }
+
   palette.properties = pipelineProperties;
-  palette.parameters = pipelineParameters;
+
+  if (pipelineParameters) {
+    palette.parameters = pipelineParameters;
+  }
 
   // Gather list of component IDs to fetch properties for.
   const componentList: string[] = [];
@@ -287,7 +334,7 @@ export const componentFetcher = async (type: string): Promise<any> => {
 };
 
 const updateRuntimeImages = (
-  properties: any,
+  properties: IComponentPropertiesResponse | undefined,
   runtimeImages: IRuntimeImage[] | undefined
 ): void => {
   const runtimeImageProperties =
@@ -313,7 +360,7 @@ const updateRuntimeImages = (
 export const usePalette = (
   type = 'local',
   additionalRuntimeImages?: IRuntimeImage[]
-): IReturn<any> => {
+): IReturn<IRuntimeComponentsResponse> => {
   const { data: runtimeImages, error: runtimeError } = useRuntimeImages(
     additionalRuntimeImages
   );
@@ -326,7 +373,7 @@ export const usePalette = (
 
   let updatedPalette;
   if (palette !== undefined) {
-    updatedPalette = produce(palette, (draft: any) => {
+    updatedPalette = produce(palette, (draft: IRuntimeComponentsResponse) => {
       for (const category of draft.categories) {
         for (const node of category.node_types) {
           // update runtime images

--- a/packages/pipeline-editor/src/pipeline-hooks.ts
+++ b/packages/pipeline-editor/src/pipeline-hooks.ts
@@ -256,7 +256,7 @@ export const componentFetcher = async (type: string): Promise<any> => {
     const category_runtime_type =
       category.node_types?.[0]?.runtime_type ?? 'LOCAL';
 
-    const type = types.find((t: any) => t.id === category_runtime_type);
+    const type = types.find((t) => t.id === category_runtime_type);
     const baseUrl = ServerConnection.makeSettings().baseUrl;
     const defaultIcon = URLExt.parse(
       URLExt.join(baseUrl, type?.icon || '')

--- a/packages/pipeline-editor/src/runtime-utils.ts
+++ b/packages/pipeline-editor/src/runtime-utils.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { IRuntime, ISchema } from './PipelineService';
+import { IMetadataResource } from '@elyra/services';
+
+import { IRuntimeSchema } from './PipelineService';
 
 export interface IRuntimeData {
   platforms: {
@@ -36,8 +38,8 @@ export const createRuntimeData = ({
   schema,
   allowLocal
 }: {
-  runtimes: IRuntime[];
-  schema: ISchema[];
+  runtimes: IMetadataResource[];
+  schema: IRuntimeSchema[];
   allowLocal?: boolean;
 }): IRuntimeData => {
   const platforms: IRuntimeData['platforms'] = [];
@@ -48,7 +50,7 @@ export const createRuntimeData = ({
     }
     platforms.push({
       id: s.runtime_type,
-      displayName: s.title,
+      displayName: s.title ?? '',
       configs: runtimes
         .filter((r) => r.metadata.runtime_type === s.runtime_type)
         .map((r) => ({

--- a/packages/pipeline-editor/src/test/pipeline-hooks.spec.ts
+++ b/packages/pipeline-editor/src/test/pipeline-hooks.spec.ts
@@ -52,7 +52,12 @@ const createMockComponent = (name: string): Component => {
     type: 'execution_node',
     inputs: [],
     outputs: [],
-    app_data: {}
+    app_data: {
+      image: 'image',
+      ui_data: {
+        image: 'ui_data_image'
+      }
+    }
   };
 };
 

--- a/packages/pipeline-editor/src/theme.tsx
+++ b/packages/pipeline-editor/src/theme.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Theme } from '@elyra/pipeline-editor/dist/types';
 import { trashIcon } from '@elyra/ui-components';
 import {
   closeIcon,
@@ -24,6 +25,7 @@ import {
   paletteIcon
 } from '@jupyterlab/ui-components';
 import * as React from 'react';
+import { DeepPartial } from 'redux';
 
 interface ISvgIconProps {
   children: React.ReactNode;
@@ -43,7 +45,7 @@ const SvgIcon: React.FC<ISvgIconProps> = ({ children }) => {
   );
 };
 
-const theme: any = {
+const theme: DeepPartial<Theme> = {
   palette: {
     focus: 'var(--jp-brand-color0)',
     border: 'var(--jp-border-color0)',
@@ -68,10 +70,6 @@ const theme: any = {
       main: 'var(--jp-error-color1)',
       contrastText: 'rgba(255, 255, 255, 0.9)',
       errorBorder: 'var(--jp-error-color0)'
-    },
-    icon: {
-      primary: 'var(--jp-ui-font-color0)',
-      secondary: 'var(--jp-ui-font-color0)'
     },
     text: {
       primary: 'var(--jp-content-font-color0)',

--- a/packages/pipeline-editor/src/utils.ts
+++ b/packages/pipeline-editor/src/utils.ts
@@ -16,8 +16,11 @@
 
 import { PIPELINE_CURRENT_VERSION } from '@elyra/pipeline-editor';
 
+import { GenericObjectType } from '@elyra/ui-components';
+
 import { LabShell } from '@jupyterlab/application';
 import { PathExt } from '@jupyterlab/coreutils';
+import { Widget } from '@lumino/widgets';
 
 import uuid4 from 'uuid/v4';
 
@@ -41,7 +44,7 @@ export default class Utils {
     gpu?: number,
     memory?: number,
     memory_limit?: number
-  ): any {
+  ): GenericObjectType {
     const generated_uuid = uuid4();
 
     const artifactName = PathExt.basename(filename, PathExt.extname(filename));
@@ -119,7 +122,7 @@ export default class Utils {
   /**
    * From a given widget, find the application shell and return it
    */
-  static getLabShell = (widget: any): LabShell => {
+  static getLabShell = (widget: Widget | null): LabShell | null => {
     while (widget !== null && !(widget instanceof LabShell)) {
       widget = widget.parent;
     }

--- a/packages/python-editor/src/index.ts
+++ b/packages/python-editor/src/index.ts
@@ -219,7 +219,7 @@ const extension: JupyterFrontEndPlugin<void> = {
 
     app.docRegistry.addWidgetFactory(factory);
 
-    factory.widgetCreated.connect((sender: any, widget: any) => {
+    factory.widgetCreated.connect((_sender, widget) => {
       void tracker.add(widget);
 
       // Notify the widget tracker if restore data needs to update
@@ -230,7 +230,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     });
 
     // Handle the settings of new widgets. Adapted from fileeditor-extension.
-    tracker.widgetAdded.connect((sender, widget) => {
+    tracker.widgetAdded.connect((_sender, widget) => {
       updateWidget(widget);
     });
 
@@ -256,6 +256,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     }
 
     // Function to create a new untitled python file, given the current working directory
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `app.commands.execute` returns a Promise<any>
     const createNew = (cwd: string): Promise<any> => {
       return app.commands
         .execute(commandIDs.newDocManager, {

--- a/packages/script-editor/src/KernelDropdown.tsx
+++ b/packages/script-editor/src/KernelDropdown.tsx
@@ -65,7 +65,7 @@ const DropDown = forwardRef<ISelect, IProps>(
       ))
     );
 
-    const handleSelection = (e: any): void => {
+    const handleSelection = (e: { target: HTMLSelectElement }): void => {
       const selection = e.target.value;
       setSelection(selection);
       callback(selection);

--- a/packages/script-editor/src/ScriptEditor.tsx
+++ b/packages/script-editor/src/ScriptEditor.tsx
@@ -45,7 +45,7 @@ import React, { RefObject } from 'react';
 
 import { ISelect, KernelDropdown } from './KernelDropdown';
 import { ScriptEditorController } from './ScriptEditorController';
-import { ScriptRunner } from './ScriptRunner';
+import { IMessageOutput, ScriptRunner } from './ScriptRunner';
 
 /**
  * ScriptEditor widget CSS classes.
@@ -255,7 +255,7 @@ export abstract class ScriptEditor extends DocumentWidget<
   /**
    * Function: Call back function passed to runner, that handles messages coming from the kernel.
    */
-  private handleKernelMsg = async (msg: any): Promise<void> => {
+  private handleKernelMsg = (msg: IMessageOutput): void => {
     let output = '';
 
     if (msg.status) {
@@ -432,19 +432,19 @@ export abstract class ScriptEditor extends DocumentWidget<
   /**
    * Function: Saves file editor content.
    */
-  private saveFile = async (): Promise<any> => {
+  private saveFile = async (): Promise<void> => {
     if (this.context.model.readOnly) {
-      return showDialog({
+      await showDialog({
         title: 'Cannot Save',
         body: 'Document is read-only',
         buttons: [Dialog.okButton()]
       });
-    }
-    void this.context.save().then(() => {
-      if (!this.isDisposed) {
-        return this.context.createCheckpoint();
-      }
       return;
+    }
+    this.context.save().then(async () => {
+      if (!this.isDisposed) {
+        await this.context.createCheckpoint();
+      }
     });
   };
 }

--- a/packages/script-editor/src/ScriptEditorController.ts
+++ b/packages/script-editor/src/ScriptEditorController.ts
@@ -84,8 +84,8 @@ export class ScriptEditorController {
 
     const empty = '';
     if (specsByLang && Object.keys(specsByLang.kernelspecs).length !== 0) {
-      const [key, value]: any = Object.entries(specsByLang.kernelspecs)[0];
-      return value.name ?? key;
+      const [key, value] = Object.entries(specsByLang.kernelspecs)[0];
+      return value?.name ?? key;
     }
     return empty;
   };

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -17,7 +17,7 @@
 import { JupyterServer } from '@jupyterlab/testutils';
 
 import { ScriptEditorController } from '../ScriptEditorController';
-import { ScriptRunner } from '../ScriptRunner';
+import { IMessageOutput, ScriptRunner } from '../ScriptRunner';
 
 jest.setTimeout(3 * 60 * 1000);
 
@@ -93,8 +93,9 @@ describe('@elyra/script-editor', () => {
 
       it('should run script', async () => {
         const code = 'print("Test")';
-        const testCallback = async (kernelMsg: any): Promise<void> =>
+        const testCallback = (kernelMsg: IMessageOutput): void => {
           kernelMsg.output && expect(kernelMsg.output).toMatch(/test/i);
+        };
         expect(kernelName).not.toBe('');
         await runner.runScript(kernelName, testPath, code, testCallback);
         await runner.shutdownSession();
@@ -102,8 +103,9 @@ describe('@elyra/script-editor', () => {
 
       it('should receive error message when running a broken script', async () => {
         const code = 'print(Broken Test)';
-        const testCallback = async (kernelMsg: any): Promise<void> =>
+        const testCallback = (kernelMsg: IMessageOutput): void => {
           kernelMsg.error && expect(kernelMsg.error.type).toMatch(/error/i);
+        };
         expect(kernelName).not.toBe('');
         await runner.runScript(kernelName, testPath, code, testCallback);
         await runner.shutdownSession();

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -19,3 +19,4 @@ import '../style/index.css';
 export * from './parsing';
 export * from './metadata';
 export * from './requests';
+export * from './types';

--- a/packages/services/src/parsing.ts
+++ b/packages/services/src/parsing.ts
@@ -15,6 +15,7 @@
  */
 
 import { RequestHandler } from './requests';
+import { IContentsPropertiesResource } from './types';
 
 const ELYRA_FILE_PARSER_API_ENDPOINT = 'elyra/contents/properties/';
 
@@ -34,13 +35,14 @@ export class ContentParser {
    * @param file_path - relative path to file
    * @returns A string array of the env vars accessed in the given file
    */
-  static async getEnvVars(file_path: string): Promise<any> {
+  static async getEnvVars(file_path: string): Promise<string[]> {
     try {
-      const response = await RequestHandler.makeGetRequest(
-        ELYRA_FILE_PARSER_API_ENDPOINT + file_path
-      );
+      const response =
+        await RequestHandler.makeGetRequest<IContentsPropertiesResource>(
+          ELYRA_FILE_PARSER_API_ENDPOINT + file_path
+        );
       // Only return environment var names (not values)
-      return Object.keys(response.env_vars);
+      return Object.keys(response?.env_vars ?? {});
     } catch (error) {
       return Promise.reject(error);
     }

--- a/packages/services/src/types.ts
+++ b/packages/services/src/types.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018-2023 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IDictionary } from './parsing';
+
+// Types extracted from `elyra/api/elyra.yaml`
+
+export interface IElyraResource {}
+
+export interface IMetadataResourceBody {
+  display_name: string;
+  schema_name: string;
+  metadata: IDictionary<unknown>;
+}
+
+export interface IMetadataResource
+  extends IElyraResource,
+    IMetadataResourceBody {
+  name: string;
+}
+
+export interface ISchemaspaceResource extends IElyraResource {
+  name: string;
+  id: string;
+  display_name: string;
+  description: string;
+}
+
+export interface ISchemaResource extends IElyraResource {
+  schemaspace: string;
+  name: string;
+  title?: string;
+  properties?: IDictionary<unknown>;
+  uihints?: {
+    title: string;
+    icon: string;
+    reference_url: string;
+  };
+}
+
+export interface IMetadataSchemaspaceResource extends IElyraResource {
+  [schemaspace: string]: IMetadataResource[];
+}
+
+export interface ISchemaSchemaspaceResource extends IElyraResource {
+  [schemaspace: string]: ISchemaResource[];
+}
+
+export interface ISchemaspacesResource extends IElyraResource {
+  schemaspaces: string[];
+}
+
+export interface IComponentCacheResource extends IElyraResource {
+  action: 'refresh';
+}
+
+export interface IContentsPropertiesResource extends IElyraResource {
+  env_vars: Record<string, string | null>;
+  inputs: Array<string>;
+  outputs: Array<string>;
+}

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -72,7 +72,7 @@ const extension: JupyterFrontEndPlugin<ILauncher> = {
 
     commands.addCommand(CommandIDs.create, {
       label: trans.__('New Launcher'),
-      execute: (args: any) => {
+      execute: (args) => {
         const cwd = args['cwd'] ? String(args['cwd']) : '';
         const id = `launcher-${Private.id++}`;
         const callback = (item: Widget): void => {
@@ -140,7 +140,7 @@ const extension: JupyterFrontEndPlugin<ILauncher> = {
     commands.addCommand(CommandIDs.openHelp, {
       label: 'Documentation',
       icon: helpIcon,
-      execute: (args: any) => {
+      execute: () => {
         window.open('https://elyra.readthedocs.io/en/latest/', '_blank');
       }
     });
@@ -149,7 +149,7 @@ const extension: JupyterFrontEndPlugin<ILauncher> = {
       label: "What's new in latest",
       caption: "What's new in this release",
       icon: whatsNewIcon,
-      execute: (args: any) => {
+      execute: () => {
         window.open(
           'https://github.com/elyra-ai/elyra/releases/latest/',
           '_blank'

--- a/packages/theme/src/launcher.tsx
+++ b/packages/theme/src/launcher.tsx
@@ -116,7 +116,7 @@ export class Launcher extends JupyterlabLauncher {
   /**
    * Render the launcher to virtual DOM nodes.
    */
-  protected render(): React.ReactElement<any> | null {
+  protected render(): React.ReactElement<React.JSX.Element> | null {
     // Bail if there is no model.
     if (!this.model) {
       return null;
@@ -128,7 +128,7 @@ export class Launcher extends JupyterlabLauncher {
     const launcherContent = launcherBody?.props.children;
     const launcherCategories = launcherContent.props.children;
 
-    const categories: React.ReactElement<any>[] = [];
+    const categories: React.ReactElement<string>[] = [];
 
     const knownCategories = [
       this._translator.__('Notebook'),
@@ -139,7 +139,7 @@ export class Launcher extends JupyterlabLauncher {
 
     // Assemble the final ordered list of categories
     // based on knownCategories.
-    each(knownCategories, (category, index) => {
+    each(knownCategories, (category) => {
       React.Children.forEach(launcherCategories, (cat) => {
         if (cat.key === category) {
           if (cat.key === ELYRA_CATEGORY) {

--- a/packages/ui-components/src/Dropzone.tsx
+++ b/packages/ui-components/src/Dropzone.tsx
@@ -31,10 +31,10 @@ interface IRootProps {
 }
 
 interface IProps {
-  onDragEnter?: (e: Drag.Event) => any;
-  onDragLeave?: (e: Drag.Event) => any;
-  onDragOver?: (e: Drag.Event) => any;
-  onDrop?: (e: Drag.Event) => any;
+  onDragEnter?: (e: Drag.Event) => void;
+  onDragLeave?: (e: Drag.Event) => void;
+  onDragOver?: (e: Drag.Event) => void;
+  onDrop?: (e: Drag.Event) => void;
   children?: React.ReactNode;
 }
 

--- a/packages/ui-components/src/ExpandableComponent.tsx
+++ b/packages/ui-components/src/ExpandableComponent.tsx
@@ -44,7 +44,7 @@ const DRAGGABLE_CLASS = 'elyra-expandableContainer-draggable';
 export interface IExpandableActionButton {
   title: string;
   icon: LabIcon;
-  onClick: () => any;
+  onClick: () => void;
   feedback?: string;
 }
 
@@ -52,9 +52,9 @@ export interface IExpandableComponentProps {
   displayName: string;
   tooltip: string;
   actionButtons?: IExpandableActionButton[];
-  onExpand?: (isExpanded: boolean) => any;
-  onBeforeExpand?: (isExpanded: boolean) => any;
-  onMouseDown?: (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => any;
+  onExpand?: (isExpanded: boolean) => void;
+  onBeforeExpand?: (isExpanded: boolean) => void;
+  onMouseDown?: (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void;
   children?: React.ReactNode;
 }
 

--- a/packages/ui-components/src/FormComponents/DropDown.tsx
+++ b/packages/ui-components/src/FormComponents/DropDown.tsx
@@ -48,7 +48,7 @@ export const DropDown: React.FC<FieldProps> = (props: FieldProps) => {
     <div>
       <input
         required={required}
-        onChange={(event: any): void => {
+        onChange={(event): void => {
           handleChange(event.target.value);
         }}
         value={current ?? ''}

--- a/packages/ui-components/src/FormComponents/Tags.tsx
+++ b/packages/ui-components/src/FormComponents/Tags.tsx
@@ -210,7 +210,7 @@ export const TagsField: React.FC<FieldProps> = (props: FieldProps) => {
   const errorSchema = props.errorSchema ?? {};
   if (Object.keys(errorSchema).length > 0) {
     for (const i in props.errorSchema) {
-      for (const err of (props.errorSchema[i] as any)['__errors']) {
+      for (const err of props.errorSchema[i]?.['__errors'] ?? []) {
         errors.push(<li className="text-danger">{err}</li>);
       }
     }

--- a/packages/ui-components/src/FormEditor.tsx
+++ b/packages/ui-components/src/FormEditor.tsx
@@ -22,10 +22,18 @@ import {
   ArrayFieldTemplateProps,
   FieldTemplateProps,
   RegistryFieldsType,
-  RegistryWidgetsType
+  RegistryWidgetsType,
+  UiSchema
 } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import * as React from 'react';
+
+type ElyraSchema = GenericObjectType & {
+  uihints?: { title: string; icon: string; reference_url: string };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- a record that holds any value
+export type GenericObjectType = Record<string, any>;
 
 /**
  * Props passed to the FormEditor.
@@ -34,12 +42,12 @@ interface IFormEditorProps {
   /**
    * Schema for form fields to be displayed.
    */
-  schema: any;
+  schema: GenericObjectType;
 
   /**
    * Handler to update form data / error state in parent component.
    */
-  onChange: (formData: any, invalid: boolean) => void;
+  onChange: (formData: GenericObjectType, invalid: boolean) => void;
 
   /**
    * Editor services to create new editors in code fields.
@@ -59,7 +67,7 @@ interface IFormEditorProps {
   /**
    * Metadata that already exists (if there is any)
    */
-  originalData?: any;
+  originalData?: GenericObjectType;
 
   /**
    * All existing tags to give as options.
@@ -148,19 +156,20 @@ export const FormEditor: React.FC<IFormEditorProps> = ({
   allTags,
   languageOptions
 }) => {
-  const [formData, setFormData] = React.useState(originalData ?? ({} as any));
+  const [formData, setFormData] = React.useState(originalData ?? {});
 
   /**
    * Generate the rjsf uiSchema from uihints in the elyra metadata schema.
    */
-  const uiSchema: any = {
+  const uiSchema: UiSchema = {
     classNames: 'elyra-formEditor'
   };
   for (const category in schema?.properties) {
-    const properties = schema.properties[category];
+    const properties = schema.properties[category] as GenericObjectType;
     uiSchema[category] = {};
     for (const field in properties.properties) {
-      uiSchema[category][field] = properties.properties[field].uihints ?? {};
+      const fieldProperties = properties.properties[field] as ElyraSchema;
+      uiSchema[category][field] = fieldProperties.uihints ?? {};
       uiSchema[category][field].classNames = `elyra-formEditor-form-${field}`;
     }
   }

--- a/packages/ui-components/src/JSONComponent.tsx
+++ b/packages/ui-components/src/JSONComponent.tsx
@@ -40,7 +40,7 @@ const theme = {
 };
 
 interface IProps {
-  json: any;
+  json: Record<string, unknown> | Array<unknown>;
 }
 
 /**
@@ -64,7 +64,7 @@ export const JSONComponent: React.FC<IProps> = ({ json }) => (
       data: string,
       itemType: string,
       itemString: string
-    ): any =>
+    ): React.ReactNode =>
       Array.isArray(data) ? (
         // Always display array type and the number of items i.e. "[] 2 items".
         <span>
@@ -77,10 +77,13 @@ export const JSONComponent: React.FC<IProps> = ({ json }) => (
         null! // Upstream typings don't accept null, but it should be ok
       )
     }
-    labelRenderer={([label, type]: [string, any]): any => {
+    labelRenderer={([label, _type]: [
+      string,
+      string | number | boolean | null | undefined
+    ]): JSX.Element => {
       return <span className="cm-keyword">{`${label}: `}</span>;
     }}
-    valueRenderer={(raw: any): any => {
+    valueRenderer={(raw: string | number): JSX.Element => {
       let className = 'cm-string';
       if (typeof raw === 'number') {
         className = 'cm-number';

--- a/packages/ui-components/src/RequestErrors.tsx
+++ b/packages/ui-components/src/RequestErrors.tsx
@@ -20,6 +20,16 @@ import * as React from 'react';
 
 import { ExpandableErrorDialog } from './ExpandableErrorDialog';
 
+export interface IErrorResponse {
+  status?: number;
+  message?: string;
+  requestPath?: string;
+  reason?: string;
+  timestamp?: string;
+  traceback?: string;
+  issues: object[];
+}
+
 /**
  * A class for handling errors when making requests to the jupyter lab server.
  */
@@ -32,7 +42,7 @@ export class RequestErrors {
    *
    * @returns A human readable multiline string for displaying the issues
    */
-  private static formatIssues(issues: any): string {
+  private static formatIssues(issues: object[]): string {
     let formatted = '';
     for (const issue of issues) {
       formatted += JSON.stringify(issue, null, 2) + '\n';
@@ -47,7 +57,7 @@ export class RequestErrors {
    *
    * @returns A promise that resolves with whether the dialog was accepted.
    */
-  static serverError(response: any): Promise<Dialog.IResult<any>> {
+  static serverError(response: IErrorResponse): Promise<Dialog.IResult<void>> {
     if (response.status === 404) {
       return this.server404(response.requestPath);
     }
@@ -87,7 +97,9 @@ export class RequestErrors {
    *
    * @returns A promise that resolves with whether the dialog was accepted.
    */
-  private static server404(endpoint: string): Promise<Dialog.IResult<any>> {
+  private static server404(
+    endpoint: string = 'unknown'
+  ): Promise<Dialog.IResult<void>> {
     return showDialog({
       title: 'Error contacting server',
       body: (
@@ -115,7 +127,7 @@ export class RequestErrors {
     schemaspace: string,
     action?: string,
     schemaName?: string
-  ): Promise<Dialog.IResult<any>> {
+  ): Promise<Dialog.IResult<void>> {
     return showDialog({
       title: action ? `Cannot ${action}` : 'Error retrieving metadata',
       body: (

--- a/tests/integration/codesnippet.ts
+++ b/tests/integration/codesnippet.ts
@@ -198,7 +198,9 @@ describe('Code Snippet tests', () => {
     const updatedSnippetItem = getSnippetByName(newSnippetName);
 
     // Check old snippet name does not exist
-    expect(updatedSnippetItem.innerText).not.to.eq(snippetName);
+    updatedSnippetItem.then((element) => {
+      expect(element.text()).not.to.eq(snippetName);
+    });
 
     // Delete updated code snippet
     deleteSnippet(newSnippetName);
@@ -337,11 +339,13 @@ const openCodeSnippetExtension = (): void => {
   cy.get('.jp-SideBar .lm-mod-current[title="Code Snippets"]');
 };
 
-const getSnippetByName = (snippetName: string): any => {
+const getSnippetByName = (
+  snippetName: string
+): Cypress.Chainable<JQuery<HTMLElement>> => {
   return cy.get(`[data-item-id="${snippetName}"]`);
 };
 
-const createInvalidCodeSnippet = (snippetName: string): any => {
+const createInvalidCodeSnippet = (snippetName: string): void => {
   clickCreateNewSnippetButton();
 
   // Name code snippet
@@ -353,7 +357,7 @@ const createInvalidCodeSnippet = (snippetName: string): any => {
 const populateCodeSnippetFields = (
   snippetName: string,
   language?: string
-): any => {
+): void => {
   clickCreateNewSnippetButton();
 
   // Name code snippet
@@ -372,7 +376,7 @@ const populateCodeSnippetFields = (
 const createValidCodeSnippet = (
   snippetName: string,
   language?: string
-): any => {
+): void => {
   populateCodeSnippetFields(snippetName, language);
 
   saveAndCloseMetadataEditor();
@@ -408,7 +412,9 @@ const duplicateSnippet = (snippetName: string): void => {
   item.find('button[title="Duplicate"]').click();
 };
 
-const getActionButtonsElement = (snippetName: string): any => {
+const getActionButtonsElement = (
+  snippetName: string
+): Cypress.Chainable<JQuery<HTMLElement>> => {
   const actionButtonsElement = getSnippetByName(snippetName).find(
     '.elyra-expandableContainer-action-buttons'
   );

--- a/tests/plugins/index.ts
+++ b/tests/plugins/index.ts
@@ -16,6 +16,7 @@
 
 import { register } from './../utils/snapshots/plugin';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- workaround for snapshot plugin
 export default (on: any, config: any): void => {
   register(on, config);
 };

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -178,7 +178,7 @@ Cypress.Commands.add('openFile', (name: string): void => {
 });
 
 Cypress.Commands.add('bootstrapFile', (name: string): void => {
-  cy.readFile(`tests/assets/${name}`).then((file: any) => {
+  cy.readFile(`tests/assets/${name}`).then((file) => {
     cy.writeFile(`build/cypress-tests/${name}`, file);
   });
 });

--- a/tests/utils/snapshots/add-commands.ts
+++ b/tests/utils/snapshots/add-commands.ts
@@ -26,6 +26,7 @@ beforeEach(() => {
   snapshotIndexTracker = {};
 });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- workaround for snapshot plugin
 const getSnapshotPath = (test: any): string => {
   const names = [];
   for (let k = test; k; k = k.parent) {
@@ -52,6 +53,7 @@ const getSnapshotPath = (test: any): string => {
 };
 
 Cypress.Commands.add('matchesSnapshot', { prevSubject: true }, (value) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- workaround for snapshot plugin
   const test = (Cypress as any).mocha.getRunner().suite.ctx.test;
 
   const path = getSnapshotPath(test);

--- a/tests/utils/snapshots/plugin.ts
+++ b/tests/utils/snapshots/plugin.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 
 import { diffStringsUnified } from 'jest-diff';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- workaround for snapshot plugin
 const createSnapshot = (value: any): string => {
   let obj = value;
 
@@ -35,6 +36,7 @@ const createSnapshot = (value: any): string => {
 
 interface ISnapshotOptions {
   path: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- workaround for snapshot plugin
   value: any;
 }
 
@@ -57,6 +59,7 @@ interface INewSnapshotResults {
   status: 'new';
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- workaround for snapshot plugin
 export const register = (on: any, _config: any): void => {
   on('task', {
     matchesSnapshot({ path, value }: ISnapshotOptions): ISnapshotResults {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3267,6 +3267,7 @@ __metadata:
     react-redux: ^7.2.0
     react-scripts: 4.0.3
     react-toastify: ^9.0.8
+    redux: ^4.2.0
     rimraf: ~5.0.5
     source-map-loader: ^0.2.4
     swr: ^0.5.6
@@ -23873,6 +23874,15 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.9.2
   checksum: 75f3955c89b3f18edf5411e5fb482aa2e4f41a416183e8802a6bf6472c4fc3d47675b8b321d147f8af8e0f616436ac507bf5a25f1c4d6180e797b549c7db2c1d
+  languageName: node
+  linkType: hard
+
+"redux@npm:^4.2.0":
+  version: 4.2.1
+  resolution: "redux@npm:4.2.1"
+  dependencies:
+    "@babel/runtime": ^7.9.2
+  checksum: f63b9060c3a1d930ae775252bb6e579b42415aee7a23c4114e21a0b4ba7ec12f0ec76936c00f546893f06e139819f0e2855e0d55ebfce34ca9c026241a6950dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-14040

Although this PR has many changes, **this is not a refactoring**. It is only meant to replace `any` with the expected types. It will help to have a safer code for future bug fixes, new features, and refactorings. After this PR, any unexplained attempt to use `any` will break the build.

A green CI is a good indication that everything is ok, however, a few changes were necessary to be incorporated to work with the types, especially null checks.

Notebook-based images to use for tests (commit 431c88e9a81594d6d56f1a7ad54310cb81d738f9):
```
ghcr.io/caponetto/opendatahub-io-elyra/workbench-images:jupyter-trustyai-ubi9-python-3.11-20241126-7650cd8-sha-431c88e9

ghcr.io/caponetto/opendatahub-io-elyra/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.11-20241126-7650cd8-sha-431c88e9
```