### PR TITLE
Append 'dev' suffix to the version on main branch

### DIFF
--- a/elyra/_version.py
+++ b/elyra/_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"
+__version__ = "0.0.0.dev"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "npmClient": "yarn",
   "command": {
     "publish": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elyra",
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/code-snippet/package.json
+++ b/packages/code-snippet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elyra/code-snippet-extension",
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "description": "JupyterLab extension - Reusable code snippets for your Notebook and Python Scripts",
   "keywords": [
     "jupyter",
@@ -52,9 +52,9 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@elyra/metadata-common": "0.0.0",
-    "@elyra/services": "0.0.0",
-    "@elyra/ui-components": "0.0.0",
+    "@elyra/metadata-common": "0.0.0-dev",
+    "@elyra/services": "0.0.0-dev",
+    "@elyra/ui-components": "0.0.0-dev",
     "@jupyterlab/application": "^4.2.5",
     "@jupyterlab/apputils": "^4.2.5",
     "@jupyterlab/builder": "^4.2.5",

--- a/packages/metadata-common/package.json
+++ b/packages/metadata-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elyra/metadata-common",
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "description": "JupyterLab - Widgets for interacting with metadata",
   "keywords": [
     "jupyter",
@@ -51,8 +51,8 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@elyra/services": "0.0.0",
-    "@elyra/ui-components": "0.0.0",
+    "@elyra/services": "0.0.0-dev",
+    "@elyra/ui-components": "0.0.0-dev",
     "@jupyterlab/application": "^4.2.5",
     "@jupyterlab/apputils": "^4.2.5",
     "@jupyterlab/codeeditor": "^4.2.5",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elyra/metadata-extension",
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "description": "JupyterLab extension - View and edit metadata",
   "keywords": [
     "jupyter",
@@ -52,8 +52,8 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@elyra/metadata-common": "0.0.0",
-    "@elyra/services": "0.0.0",
+    "@elyra/metadata-common": "0.0.0-dev",
+    "@elyra/services": "0.0.0-dev",
     "@jupyterlab/application": "^4.2.5",
     "@jupyterlab/apputils": "^4.2.5",
     "@jupyterlab/builder": "^4.2.5",

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elyra/pipeline-editor-extension",
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "description": "JupyterLab extension - Visual editor to build Notebook pipelines",
   "keywords": [
     "jupyter",
@@ -53,11 +53,11 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@elyra/metadata-common": "0.0.0",
+    "@elyra/metadata-common": "0.0.0-dev",
     "@elyra/pipeline-editor": "1.12.1",
     "@elyra/pipeline-services": "1.12.1",
-    "@elyra/services": "0.0.0",
-    "@elyra/ui-components": "0.0.0",
+    "@elyra/services": "0.0.0-dev",
+    "@elyra/ui-components": "0.0.0-dev",
     "@jupyterlab/application": "^4.2.5",
     "@jupyterlab/apputils": "^4.2.5",
     "@jupyterlab/builder": "^4.2.5",

--- a/packages/python-editor/package.json
+++ b/packages/python-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elyra/python-editor-extension",
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "description": "JupyterLab extension - Run python scripts using a kernel runtime",
   "keywords": [
     "jupyter",
@@ -52,8 +52,8 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@elyra/script-editor": "0.0.0",
-    "@elyra/ui-components": "0.0.0",
+    "@elyra/script-editor": "0.0.0-dev",
+    "@elyra/ui-components": "0.0.0-dev",
     "@jupyterlab/application": "^4.2.5",
     "@jupyterlab/apputils": "^4.2.5",
     "@jupyterlab/codeeditor": "^4.2.5",

--- a/packages/script-debugger/package.json
+++ b/packages/script-debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elyra/script-debugger-extension",
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "description": "JupyterLab extension - visual debugging support for script editors",
   "keywords": [
     "jupyter",
@@ -52,7 +52,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@elyra/script-editor": "0.0.0",
+    "@elyra/script-editor": "0.0.0-dev",
     "@jupyterlab/application": "^4.2.5",
     "@jupyterlab/debugger": "^4.2.5",
     "@jupyterlab/fileeditor": "^4.2.5",

--- a/packages/script-editor/package.json
+++ b/packages/script-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elyra/script-editor",
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "description": "JupyterLab - Run python and R scripts using a kernel runtime",
   "keywords": [
     "jupyter",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elyra/services",
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "description": "JupyterLab - Utilities for use in elyra",
   "keywords": [
     "jupyter",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elyra/theme-extension",
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "description": "JupyterLab extension - Elyra theme",
   "keywords": [
     "jupyter",
@@ -52,7 +52,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@elyra/ui-components": "0.0.0",
+    "@elyra/ui-components": "0.0.0-dev",
     "@jupyterlab/application": "^4.2.5",
     "@jupyterlab/apputils": "^4.2.5",
     "@jupyterlab/builder": "^4.2.5",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elyra/ui-components",
-  "version": "0.0.0",
+  "version": "0.0.0-dev",
   "description": "JupyterLab - UI components for use in elyra",
   "keywords": [
     "jupyter",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,9 +3148,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@elyra/code-snippet-extension@workspace:packages/code-snippet"
   dependencies:
-    "@elyra/metadata-common": 0.0.0
-    "@elyra/services": 0.0.0
-    "@elyra/ui-components": 0.0.0
+    "@elyra/metadata-common": 0.0.0-dev
+    "@elyra/services": 0.0.0-dev
+    "@elyra/ui-components": 0.0.0-dev
     "@jupyterlab/application": ^4.2.5
     "@jupyterlab/apputils": ^4.2.5
     "@jupyterlab/builder": ^4.2.5
@@ -3179,12 +3179,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elyra/metadata-common@0.0.0, @elyra/metadata-common@workspace:packages/metadata-common":
+"@elyra/metadata-common@0.0.0-dev, @elyra/metadata-common@workspace:packages/metadata-common":
   version: 0.0.0-use.local
   resolution: "@elyra/metadata-common@workspace:packages/metadata-common"
   dependencies:
-    "@elyra/services": 0.0.0
-    "@elyra/ui-components": 0.0.0
+    "@elyra/services": 0.0.0-dev
+    "@elyra/ui-components": 0.0.0-dev
     "@jupyterlab/application": ^4.2.5
     "@jupyterlab/apputils": ^4.2.5
     "@jupyterlab/builder": ^4.2.5
@@ -3206,8 +3206,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@elyra/metadata-extension@workspace:packages/metadata"
   dependencies:
-    "@elyra/metadata-common": 0.0.0
-    "@elyra/services": 0.0.0
+    "@elyra/metadata-common": 0.0.0-dev
+    "@elyra/services": 0.0.0-dev
     "@jupyterlab/application": ^4.2.5
     "@jupyterlab/apputils": ^4.2.5
     "@jupyterlab/builder": ^4.2.5
@@ -3224,11 +3224,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@elyra/pipeline-editor-extension@workspace:packages/pipeline-editor"
   dependencies:
-    "@elyra/metadata-common": 0.0.0
+    "@elyra/metadata-common": 0.0.0-dev
     "@elyra/pipeline-editor": 1.12.1
     "@elyra/pipeline-services": 1.12.1
-    "@elyra/services": 0.0.0
-    "@elyra/ui-components": 0.0.0
+    "@elyra/services": 0.0.0-dev
+    "@elyra/ui-components": 0.0.0-dev
     "@jupyterlab/application": ^4.2.5
     "@jupyterlab/apputils": ^4.2.5
     "@jupyterlab/builder": ^4.2.5
@@ -3324,8 +3324,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@elyra/python-editor-extension@workspace:packages/python-editor"
   dependencies:
-    "@elyra/script-editor": 0.0.0
-    "@elyra/ui-components": 0.0.0
+    "@elyra/script-editor": 0.0.0-dev
+    "@elyra/ui-components": 0.0.0-dev
     "@jupyterlab/application": ^4.2.5
     "@jupyterlab/apputils": ^4.2.5
     "@jupyterlab/builder": ^4.2.5
@@ -3347,7 +3347,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@elyra/script-debugger-extension@workspace:packages/script-debugger"
   dependencies:
-    "@elyra/script-editor": 0.0.0
+    "@elyra/script-editor": 0.0.0-dev
     "@jupyterlab/application": ^4.2.5
     "@jupyterlab/builder": ^4.2.5
     "@jupyterlab/debugger": ^4.2.5
@@ -3359,7 +3359,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elyra/script-editor@0.0.0, @elyra/script-editor@workspace:packages/script-editor":
+"@elyra/script-editor@0.0.0-dev, @elyra/script-editor@workspace:packages/script-editor":
   version: 0.0.0-use.local
   resolution: "@elyra/script-editor@workspace:packages/script-editor"
   dependencies:
@@ -3389,7 +3389,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elyra/services@0.0.0, @elyra/services@workspace:packages/services":
+"@elyra/services@0.0.0-dev, @elyra/services@workspace:packages/services":
   version: 0.0.0-use.local
   resolution: "@elyra/services@workspace:packages/services"
   dependencies:
@@ -3418,7 +3418,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@elyra/theme-extension@workspace:packages/theme"
   dependencies:
-    "@elyra/ui-components": 0.0.0
+    "@elyra/ui-components": 0.0.0-dev
     "@jupyterlab/application": ^4.2.5
     "@jupyterlab/apputils": ^4.2.5
     "@jupyterlab/builder": ^4.2.5
@@ -3435,7 +3435,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elyra/ui-components@0.0.0, @elyra/ui-components@workspace:packages/ui-components":
+"@elyra/ui-components@0.0.0-dev, @elyra/ui-components@workspace:packages/ui-components":
   version: 0.0.0-use.local
   resolution: "@elyra/ui-components@workspace:packages/ui-components"
   dependencies:


### PR DESCRIPTION
This way, we are compatible with the [original code](https://github.com/opendatahub-io/elyra/blob/main/elyra/pipeline/kfp/processor_kfp.py#L1065) and we don't need to set up one additional env var when testing versions from `main`.