### PR TITLE
Pin Ubuntu `22.04` on `validate-images` job to unblock the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,7 +242,7 @@ jobs:
 
   validate-images:
     name: Validate Images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # This job is failing on Ubuntu 24.04
     steps:
       - uses: actions/checkout@v4
       - name: Validate runtime images


### PR DESCRIPTION
A permanent solution that works on `ubuntu-latest` (`24.04`) will be investigated.