### PR TITLE
Unpin `nbconvert` since the issue with `mistune` is resolved

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "MarkupSafe>=2.1",
     "minio>=7.0.0,!=7.2.1",
     "nbclient>=0.10.0",
-    "nbconvert==7.1.0",  # Ensure compatibility with mistune<3 as `3.1.0` has issues (see https://github.com/lepture/mistune/issues/403)
+    "nbconvert>=6.5.1",
     "nbdime~=4.0.1",  # Cap from jupyterlab-git
     "nbformat>=5.1.2",
     "networkx>=2.5.1",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,6 +8,5 @@ pytest-console-scripts
 pytest_jupyter
 pytest-tornasync
 pytest_virtualenv
-nbconvert==7.1.0
 requests-mock
 requests-unixsocket


### PR DESCRIPTION
Rollback https://github.com/opendatahub-io/elyra/pull/96 since https://github.com/jupyter/nbconvert/issues/2198 is resolved and released.