### PR TITLE
Rename env var `PIPELINES_SSL_SA_CERTS` -> `KF_PIPELINES_SSL_SA_CERTS`

### DIFF
--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -221,6 +221,9 @@ The KubeFlow Pipelines API endpoint you want to utilize. This setting is require
 
 Example: `https://kubernetes-service.domain.com/pipeline`
 
+*Note*: In setups where the Kubeflow Pipeline server is secured with a custom certificate, users can specify this certificate path by setting the environment variable `KF_PIPELINES_SSL_SA_CERT` in the jupyter environment. This variable directs the Kubeflow Pipelines SDK client to use the provided certificate for accessing the Kubeflow Pipeline server. For more information, see the [ssl_ca_cert](https://kubeflow-pipelines.readthedocs.io/en/stable/source/client.html#kfp.client.Client.__init__.ssl_ca_cert) attribute in the `kfp` SDK documentation.  
+Ex: `KF_PIPELINES_SSL_SA_CERT:/path/to/certs`
+
 
 ##### Public Kubeflow Pipelines API endpoint (public_api_endpoint)
 

--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -221,8 +221,8 @@ The KubeFlow Pipelines API endpoint you want to utilize. This setting is require
 
 Example: `https://kubernetes-service.domain.com/pipeline`
 
-*Note*: In setups where the Kubeflow Pipeline server is secured with a custom certificate, users can specify this certificate path by setting the environment variable `KF_PIPELINES_SSL_SA_CERT` in the jupyter environment. This variable directs the Kubeflow Pipelines SDK client to use the provided certificate for accessing the Kubeflow Pipeline server. For more information, see the [ssl_ca_cert](https://kubeflow-pipelines.readthedocs.io/en/stable/source/client.html#kfp.client.Client.__init__.ssl_ca_cert) attribute in the `kfp` SDK documentation.  
-Ex: `KF_PIPELINES_SSL_SA_CERT:/path/to/certs`
+*Note*: In setups where the Kubeflow Pipeline server is secured with a custom certificate, users can specify this certificate path by setting the environment variable `KF_PIPELINES_SSL_SA_CERTS` in the jupyter environment. This variable directs the Kubeflow Pipelines SDK client to use the provided certificate for accessing the Kubeflow Pipeline server. For more information, see the [ssl_ca_cert](https://kubeflow-pipelines.readthedocs.io/en/stable/source/client.html#kfp.client.Client.__init__.ssl_ca_cert) attribute in the `kfp` SDK documentation.  
+Ex: `KF_PIPELINES_SSL_SA_CERTS:/path/to/certs`
 
 
 ##### Public Kubeflow Pipelines API endpoint (public_api_endpoint)

--- a/elyra/pipeline/kfp/kfp_authentication.py
+++ b/elyra/pipeline/kfp/kfp_authentication.py
@@ -230,7 +230,7 @@ class KFPAuthenticator:
         """
 
         kf_url = urlsplit(api_endpoint)._replace(path="").geturl()
-        kf_pipelines_ssl_sa_cert = os.getenv("KF_PIPELINES_SSL_SA_CERTS", None)
+        kf_pipelines_ssl_sa_certs = os.getenv("KF_PIPELINES_SSL_SA_CERTS", None)
 
         # return data structure for successful requests
         auth_info = {
@@ -240,7 +240,7 @@ class KFPAuthenticator:
             "cookies": None,  # passed to KFP SDK client as "cookies" param value
             "credentials": None,  # passed to KFP SDK client as "credentials" param value
             "existing_token": None,  # passed to KFP SDK client as "existing_token" param value
-            "ssl_ca_cert": kf_pipelines_ssl_sa_cert,  # passed to KFP SDK Client as "ssl_ca_cert" param value
+            "ssl_ca_cert": kf_pipelines_ssl_sa_certs,  # passed to KFP SDK Client as "ssl_ca_cert" param value
         }
 
         try:

--- a/elyra/pipeline/kfp/kfp_authentication.py
+++ b/elyra/pipeline/kfp/kfp_authentication.py
@@ -230,7 +230,7 @@ class KFPAuthenticator:
         """
 
         kf_url = urlsplit(api_endpoint)._replace(path="").geturl()
-        kf_pipelines_ssl_sa_cert = os.getenv("PIPELINES_SSL_SA_CERTS", None)
+        kf_pipelines_ssl_sa_cert = os.getenv("KF_PIPELINES_SSL_SA_CERTS", None)
 
         # return data structure for successful requests
         auth_info = {


### PR DESCRIPTION
Move towards a more similar codebase between this fork and upstream.

Cherry-pick from upstream: https://github.com/elyra-ai/elyra/pull/3150