### PR TITLE
RHOAIENG-16247: Add option to append the run ID to Cloud Object Storage output paths

### DIFF
--- a/elyra/airflow/operator.py
+++ b/elyra/airflow/operator.py
@@ -53,6 +53,7 @@ class BootscriptBuilder(object):
         cos_endpoint: str,
         cos_bucket: str,
         cos_directory: str,
+        cos_output_append_run_id: bool,
         cos_dependencies_archive: str,
         inputs: Optional[List[str]] = None,
         outputs: Optional[List[str]] = None,
@@ -65,6 +66,7 @@ class BootscriptBuilder(object):
         :param :cos_endpoint: object storage endpoint e.g weaikish1.fyre.ibm.com:30442
         :param :cos_bucket: bucket to retrieve archive from
         :param :cos_directory: name of the directory in the object storage bucket to pull
+        :param :cos_output_append_run_id: whether to append the run id to the output file path
         :param :cos_dependencies_archive: archive file name to get from object storage bucket e.g archive1.tar.gz
         :param inputs: comma delimited list of files to be consumed/are required by the filename
         :param outputs: comma delimited list of files produced by the filename
@@ -73,6 +75,7 @@ class BootscriptBuilder(object):
         self.cos_endpoint = cos_endpoint
         self.cos_bucket = cos_bucket
         self.cos_directory = cos_directory
+        self.cos_output_append_run_id = cos_output_append_run_id
         self.cos_dependencies_archive = cos_dependencies_archive
         self.filename = filename
         self.pipeline_name = pipeline_name
@@ -103,6 +106,7 @@ class BootscriptBuilder(object):
             f"--cos-endpoint {self.cos_endpoint} "
             f"--cos-bucket {self.cos_bucket} "
             f"--cos-directory '{self.cos_directory}' "
+            f"{'--cos-output-append-run-id ' if self.cos_output_append_run_id else ''}"
             f"--cos-dependencies-archive '{self.cos_dependencies_archive}' "
             f"--file '{self.filename}' "
         ]

--- a/elyra/kfp/bootstrapper.py
+++ b/elyra/kfp/bootstrapper.py
@@ -84,6 +84,7 @@ class FileOpBase(ABC):
         self.input_params = kwargs or {}
         self.cos_endpoint = urlparse(self.input_params.get("cos-endpoint"))
         self.cos_bucket = self.input_params.get("cos-bucket")
+        self.append_run_id = self.input_params.get("cos-output-append-run-id")
 
         self.parameter_pass_method = self.input_params.get("parameter_pass_method")
         self.pipeline_param_dict = self.convert_param_str_to_dict(self.input_params.get("pipeline_parameters"))
@@ -312,6 +313,10 @@ class FileOpBase(ABC):
         object_to_upload = object_name
         if not object_to_upload:
             object_to_upload = file_to_upload
+
+        run_id = os.getenv("ELYRA_RUN_NAME")
+        if self.append_run_id and run_id:
+            object_to_upload = os.path.join(run_id, object_to_upload)
 
         object_to_upload = self.get_object_storage_filename(object_to_upload)
         t0 = time.time()
@@ -714,6 +719,15 @@ class OpUtil(object):
             dest="pipeline-name",
             help="Pipeline name",
             required=True,
+        )
+        parser.add_argument(
+            "-a",
+            "--cos-output-append-run-id",
+            dest="cos-output-append-run-id",
+            type=bool,
+            help="Append run ID to the cloud object storage output path",
+            required=False,
+            action=argparse.BooleanOptionalAction,
         )
         parser.add_argument(
             "-r",

--- a/elyra/pipeline/airflow/airflow_processor.py
+++ b/elyra/pipeline/airflow/airflow_processor.py
@@ -255,6 +255,7 @@ be fully qualified (i.e., prefixed with their package names).
         artifact_object_prefix = join_paths(
             pipeline.pipeline_properties.get(pipeline_constants.COS_OBJECT_PREFIX), pipeline_instance_id
         )
+        cos_output_append_run_id = pipeline.pipeline_properties.get(pipeline_constants.COS_OUTPUT_APPEND_RUN_ID, False)
 
         self.log_pipeline_info(
             pipeline_name,
@@ -327,6 +328,7 @@ be fully qualified (i.e., prefixed with their package names).
                     cos_endpoint=cos_endpoint,
                     cos_bucket=cos_bucket,
                     cos_directory=artifact_object_prefix,
+                    cos_output_append_run_id=cos_output_append_run_id,
                     cos_dependencies_archive=operation_artifact_archive,
                     inputs=operation.inputs,
                     outputs=operation.outputs,

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -708,6 +708,9 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
             artifact_object_prefix = join_paths(
                 pipeline.pipeline_properties.get(pipeline_constants.COS_OBJECT_PREFIX), pipeline_instance_id
             )
+            cos_output_append_run_id = pipeline.pipeline_properties.get(
+                pipeline_constants.COS_OUTPUT_APPEND_RUN_ID, False
+            )
             # - load the generic component definition template
             template_env = Environment(loader=PackageLoader("elyra", "templates/kubeflow/v2"))
             generic_component_template = template_env.get_template("generic_component_definition_template.jinja2")
@@ -781,6 +784,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                         cos_endpoint=cos_endpoint,
                         cos_bucket=cos_bucket,
                         cos_directory=artifact_object_prefix,
+                        cos_output_append_run_id=cos_output_append_run_id,
                         cos_dependencies_archive=self._get_dependency_archive_name(operation),
                         filename=operation.filename,
                         cos_inputs=operation.inputs,
@@ -1046,6 +1050,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
         cos_endpoint: str,
         cos_bucket: str,
         cos_directory: str,
+        cos_output_append_run_id: bool,
         cos_dependencies_archive: str,
         filename: str,
         cos_inputs: Optional[List[str]] = [],
@@ -1119,6 +1124,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
             f"--cos-endpoint '{cos_endpoint}' "
             f"--cos-bucket '{cos_bucket}' "
             f"--cos-directory '{cos_directory}' "
+            f"{'--cos-output-append-run-id ' if cos_output_append_run_id else ''}"
             f"--cos-dependencies-archive '{cos_dependencies_archive}' "
             f"--file '{filename}' "
         ]

--- a/elyra/pipeline/pipeline_constants.py
+++ b/elyra/pipeline/pipeline_constants.py
@@ -26,3 +26,4 @@ KUBERNETES_POD_LABELS = "kubernetes_pod_labels"
 DISABLE_NODE_CACHING = "disable_node_caching"
 KUBERNETES_SHARED_MEM_SIZE = "kubernetes_shared_mem_size"
 COS_OBJECT_PREFIX = "cos_object_prefix"  # optional static prefix to be used when generating object name for cos storage
+COS_OUTPUT_APPEND_RUN_ID = "cos_output_append_run_id"  # optional flag to append run id to cos output path

--- a/elyra/templates/pipeline/pipeline_properties_template.jinja2
+++ b/elyra/templates/pipeline/pipeline_properties_template.jinja2
@@ -35,6 +35,15 @@
             "ui:placeholder": "project/subproject"
           }
         },
+        "cos_output_append_run_id": {
+          "title": "Append Run ID to Output Path",
+          "type": "boolean",
+          "description": "If enabled, the Run ID will be appended to the output path in Object Storage.",
+          "uihints": {
+            "ui:widget": "checkbox",
+            "ui:help": "Useful for distinguishing outputs from different runs."
+          }
+        },
         {% if elyra_owned_properties %}
         "node_defaults_header": {
           "type": "null",

--- a/elyra/tests/airflow/test_airflow_operator.py
+++ b/elyra/tests/airflow/test_airflow_operator.py
@@ -76,6 +76,7 @@ def test_fail_with_empty_string_as_filename():
             cos_endpoint="http://testserver:32525",
             cos_bucket="test_bucket",
             cos_directory="test_directory",
+            cos_output_append_run_id=False,
             cos_dependencies_archive="test_archive.tgz",
         )
     assert "You need to provide a filename for the operation." == str(error_info.value)
@@ -91,6 +92,7 @@ def test_build_cmd_with_inputs_and_outputs():
         cos_endpoint="http://testserver:32525",
         cos_bucket="test_bucket",
         cos_directory="test_directory",
+        cos_output_append_run_id=False,
         cos_dependencies_archive="test_archive.tgz",
         inputs=pipeline_inputs,
         outputs=pipeline_outputs,
@@ -106,3 +108,26 @@ def test_build_cmd_with_inputs_and_outputs():
             assert arg_value == f"'{';'.join(pipeline_outputs)}'"
         if "inputs" in arg:
             assert arg_value == f"'{';'.join(pipeline_inputs)}'"
+
+
+@pytest.mark.parametrize(
+    "cos_output_append_run_id, expected_in_cmd",
+    [
+        (False, False),
+        (True, True),
+    ],
+)
+def test_cos_output_append_run_id(cos_output_append_run_id, expected_in_cmd):
+    boot_build = BootscriptBuilder(
+        filename="test_notebook.ipynb",
+        pipeline_name="test-pipeline",
+        cos_endpoint="http://testserver:32525",
+        cos_bucket="test_bucket",
+        cos_directory="test_directory",
+        cos_output_append_run_id=cos_output_append_run_id,
+        cos_dependencies_archive="test_archive.tgz",
+    )
+    if expected_in_cmd:
+        assert "--cos-output-append-run-id" in boot_build.container_cmd
+    else:
+        assert "--cos-output-append-run-id" not in boot_build.container_cmd

--- a/elyra/tests/pipeline/airflow/test_processor_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_processor_airflow.py
@@ -31,6 +31,7 @@ from elyra.pipeline.airflow.airflow_processor import AirflowPipelineProcessor
 from elyra.pipeline.parser import PipelineParser
 from elyra.pipeline.pipeline import GenericOperation
 from elyra.pipeline.pipeline_constants import COS_OBJECT_PREFIX
+from elyra.pipeline.pipeline_constants import COS_OUTPUT_APPEND_RUN_ID
 from elyra.pipeline.pipeline_constants import MOUNTED_VOLUMES
 from elyra.pipeline.properties import ElyraProperty
 from elyra.pipeline.runtime_type import RuntimeProcessorType
@@ -177,6 +178,12 @@ def test_create_file(monkeypatch, processor, parsed_pipeline, parsed_ordered_dic
     # Ensure the value of COS_OBJECT_PREFIX has been propagated to the Pipeline object appropriately
     cos_prefix = pipeline_json["pipelines"][0]["app_data"]["properties"]["pipeline_defaults"].get(COS_OBJECT_PREFIX)
     assert cos_prefix == parsed_pipeline.pipeline_properties.get(COS_OBJECT_PREFIX)
+
+    # Ensure the value of COS_OUTPUT_APPEND_RUN_ID has been propagated to the Pipeline object appropriately
+    cos_output_append_run_id = pipeline_json["pipelines"][0]["app_data"]["properties"]["pipeline_defaults"].get(
+        COS_OUTPUT_APPEND_RUN_ID
+    )
+    assert cos_output_append_run_id == parsed_pipeline.pipeline_properties.get(COS_OUTPUT_APPEND_RUN_ID)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         export_pipeline_output_path = os.path.join(temp_dir, f"{export_pipeline_name}.py")

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -118,6 +118,7 @@ def test_compose_container_command_args(processor: KfpPipelineProcessor):
     cos_endpoint = "https://minio:9000"
     cos_bucket = "test_bucket"
     cos_directory = "a_dir"
+    cos_output_append_run_id = True
     cos_dependencies_archive = "dummy-notebook-0815.tar.gz"
     filename = "dummy-notebook.ipynb"
 
@@ -126,6 +127,7 @@ def test_compose_container_command_args(processor: KfpPipelineProcessor):
         cos_endpoint=cos_endpoint,
         cos_bucket=cos_bucket,
         cos_directory=cos_directory,
+        cos_output_append_run_id=cos_output_append_run_id,
         cos_dependencies_archive=cos_dependencies_archive,
         filename=filename,
     )
@@ -134,6 +136,7 @@ def test_compose_container_command_args(processor: KfpPipelineProcessor):
     assert f"--cos-endpoint '{cos_endpoint}'" in command_args
     assert f"--cos-bucket '{cos_bucket}'" in command_args
     assert f"--cos-directory '{cos_directory}'" in command_args
+    assert "--cos-output-append-run-id" in command_args
     assert f"--cos-dependencies-archive '{cos_dependencies_archive}'" in command_args
     assert f"--file '{filename}'" in command_args
 
@@ -148,6 +151,7 @@ def test_compose_container_command_args(processor: KfpPipelineProcessor):
                 cos_endpoint=cos_endpoint,
                 cos_bucket=cos_bucket,
                 cos_directory=cos_directory,
+                cos_output_append_run_id=True,
                 cos_dependencies_archive=cos_dependencies_archive,
                 filename=filename,
                 cos_inputs=file_dependency,
@@ -199,6 +203,7 @@ def test_compose_container_command_args_invalid_dependency_filename(processor: K
                     cos_endpoint=cos_endpoint,
                     cos_bucket=cos_bucket,
                     cos_directory=cos_directory,
+                    cos_output_append_run_id=True,
                     cos_dependencies_archive=cos_dependencies_archive,
                     filename=filename,
                     cos_inputs=file_dependency,

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_dependency_complex.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_dependency_complex.json
@@ -634,7 +634,8 @@
         },
         "properties": {
           "pipeline_defaults": {
-            "cos_object_prefix": "test/prefix"
+            "cos_object_prefix": "test/prefix",
+            "cos_output_append_run_id": "true"
           }
         },
         "version": 5,

--- a/elyra/tests/pipeline/resources/test_pipelines/kfp/kfp-one-node-generic.pipeline
+++ b/elyra/tests/pipeline/resources/test_pipelines/kfp/kfp-one-node-generic.pipeline
@@ -96,7 +96,8 @@
             "kubernetes_secrets": [],
             "env_vars": [],
             "runtime_image": "tensorflow/tensorflow:2.8.0",
-            "cos_object_prefix": "my/project"
+            "cos_object_prefix": "my/project",
+            "cos_output_append_run_id": "true"
           },
           "name": "kfp-one-node-generic",
           "runtime": "Kubeflow Pipelines",

--- a/elyra/tests/pipeline/test_handlers.py
+++ b/elyra/tests/pipeline/test_handlers.py
@@ -28,6 +28,7 @@ from elyra.metadata.schemaspaces import ComponentCatalogs
 from elyra.pipeline.parser import PipelineParser
 from elyra.pipeline.pipeline_constants import (
     COS_OBJECT_PREFIX,
+    COS_OUTPUT_APPEND_RUN_ID,
     DISABLE_NODE_CACHING,
     ENV_VARIABLES,
     KUBERNETES_POD_ANNOTATIONS,
@@ -266,6 +267,7 @@ async def test_get_pipeline_properties_definition(jp_fetch):
 
         default_properties = [
             COS_OBJECT_PREFIX,
+            COS_OUTPUT_APPEND_RUN_ID,
             RUNTIME_IMAGE,
             ENV_VARIABLES,
             KUBERNETES_SECRETS,


### PR DESCRIPTION
See https://issues.redhat.com/browse/RHOAIENG-16247 for more information

### Description

This PR adds the option to append the run ID to Cloud Object Storage (COS) output paths. This way, output files are not overridden when a new run is triggered from the same pipeline execution on the Dashboard. Notice that the current behavior is kept as default to avoid breaking existing flows. Users who want to use this feature must deliberately enable it through the new property.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/84387bc7-8814-4929-8090-8b9217ee941e" />


In case the property is _not set_, then the output files will be stored in a path like (current behavior):
`<bucket_name>/<pipeline_name>-<timestamp>/<output_file>`

In case the property is _set_, then the output files will be stored in a path like:
`<bucket_name>/<pipeline_name>-<timestamp>/<run_id>/<output_file>`

### Validation

Be sure to have the Pipeline server, COS and connection correctly set up on ODH. 

#### Step 1

Run this code locally and connect to a running ODH or build a notebook-based image with an Elyra version that includes the changes from this PR. 

Alternativelly, you can use the image that is built from this code through our automation: `ghcr.io/caponetto/opendatahub-io-elyra/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.11-20250124-adbd066-sha-9c4c8ebf` (this image is based on quay.io/opendatahub/workbench-images and simply uninstalls the current ODH Elyra and installs the ODH Elyra built from this code). The following steps use this image.

#### Step 2

Import the new image into ODH and create a new workbench from it. Be sure to set up the following env vars so that the updated `bootstrapper.py` is downloaded and used:

```
ELYRA_FILE_BASE_PATH=/opt/app-root/bin (or any other folder)
ELYRA_GITHUB_BRANCH=RHOAIENG-16247
ELYRA_GITHUB_ORG=caponetto
ELYRA_GITHUB_REPO=opendatahub-io-elyra
```
Given recent changes not propagated to notebooks yet, you also need to set up:
```
KF_PIPELINES_SSL_SA_CERTS=/etc/pki/tls/custom-certs/ca-bundle.crt
```

#### Step 3

Open up the newly created workbench and add a pipeline that stores files to COS. An example can be found [here](https://github.com/redhat-rhods-qe/ods-ci-notebooks-main/tree/main/notebooks/500__jupyterhub/pipelines/v2/elyra/test-output-overwrite), which stores a text file to COS.

#### Step 4

Keep the new property disabled and run the pipeline. It is expected that output files be stored on:
`<bucket_name>/<pipeline_name>-<timestamp>/<output_file>`

<img width="300" alt="image" src="https://github.com/user-attachments/assets/da8231fd-eeb8-4434-b861-d054f48a46e3" />

If you create a new run from Dashboard, the output files will be overridden, which is the current behavior.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b040ece7-fcf5-44c1-a66b-39ebe3d30394" />


#### Step 5

Enable the new property and run the pipeline again. 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/8719a00a-e672-426a-ac4f-2c9e3dc02b64" />

It is expected that output files be stored on:
`<bucket_name>/<pipeline_name>-<timestamp>/<run_id>/<output_file>`

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6bb5a571-a963-4438-a501-d6ea906f9108" />


<img width="300" alt="image" src="https://github.com/user-attachments/assets/7bff05bb-f86b-4e39-8b94-9f500ed72d8f" />

Notice that, the run ID in the folder matches with the information on the Dashboard:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6894c03b-c442-4b40-8fea-05a2ee94f9dd" />

If you create a new run from Dashboard, the output files from the run will be stored in a new folder.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/c51feb01-88aa-4dda-916a-7f23bf0a839f" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/78896f0a-f017-4606-bea4-7da44881d173" />

