### PR TITLE
Update JupyterLab version compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "hatchling.build"
 requires = [
     "hatchling>=1.5.0",
-    "jupyterlab~=4.2.5",
+    "jupyterlab>=4.2.5,<4.5",
     "hatch-nodejs-version>=0.3.2"
 ]
 
@@ -27,7 +27,7 @@ dependencies = [
     "jupyter-events>=0.6.2",
     "jupyter-packaging>=0.10",
     "jupyter_server>=1.7.0",
-    "jupyterlab~=4.2.5",  # comment out to use local jupyterlab
+    "jupyterlab>=4.2.5,<4.5",  # comment out to use local jupyterlab
     "jupyterlab-lsp~=5.1.0",  # comment out to use local jupyterlab
     "jupyterlab-git~=0.50.0",  # Avoid breaking 1.x changes
     "jupyter-resource-usage~=1.1.0",


### PR DESCRIPTION
Although the JupyterLab version that we have been extensively testing is `4.2.x` in our images (see [here](https://github.com/opendatahub-io/notebooks/blob/main/jupyter/minimal/ubi9-python-3.11/Pipfile#L11)), this PR increases the compatibility with JupyterLab up to the version `4.4`, which allows us to start validating the new versions.