### PR TITLE
Remove unneeded `packageManager` from `package.json` to fix the CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,5 @@
     "typedoc-plugin-mdn-links": "^3.0.3",
     "typescript": "~5.1.6",
     "webpack": "^5.76.1"
-  },
-  "packageManager": "yarn@3.5.0"
+  }
 }


### PR DESCRIPTION
The `packageManager` prop was unintentionally added by the update-version workflow and will be introduced only when we cherry-pick https://github.com/elyra-ai/elyra/pull/3292 from upstream.