### PR TITLE
RHOAIENG-11446: Add task-level cache control

### DIFF
--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -886,10 +886,6 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                     # Use Kubeflow Pipelines provided RUN_ID_PLACEHOLDER as run name
                     workflow_task["task_modifiers"]["set_run_name"] = RUN_ID_PLACEHOLDER
 
-                disable_node_caching = pipeline.pipeline_properties.get(pipeline_constants.DISABLE_NODE_CACHING)
-                if disable_node_caching:
-                    workflow_task["task_modifiers"]["disable_node_caching"] = disable_node_caching.selection
-
                 # Upload dependencies to cloud storage
                 self._upload_dependencies_to_object_store(
                     runtime_configuration, pipeline_name, operation, prefix=artifact_object_prefix
@@ -1191,12 +1187,9 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
 
     def add_disable_node_caching(self, instance: DisableNodeCaching, execution_object: Any, **kwargs) -> None:
         """Add DisableNodeCaching info to the execution object"""
-        # Force re-execution of the operation by setting staleness to zero days
-        # https://www.kubeflow.org/docs/components/pipelines/overview/caching/#managing-caching-staleness
-        if instance.selection:
-            execution_object["disable_node_caching"] = True
-        else:
-            execution_object["disable_node_caching"] = False
+        if instance is None:
+            return
+        execution_object["disable_node_caching"] = instance.selection
 
     def add_custom_shared_memory_size(self, instance: CustomSharedMemorySize, execution_object: Any, **kwargs) -> None:
         """Add CustomSharedMemorySize info to the execution object"""

--- a/elyra/pipeline/properties.py
+++ b/elyra/pipeline/properties.py
@@ -370,7 +370,7 @@ class ElyraProperty(ABC):
 class DisableNodeCaching(ElyraProperty):
     """An ElyraProperty representing node cache preference"""
 
-    applies_to_generic = False
+    applies_to_generic = True
     applies_to_custom = True
 
     property_id = DISABLE_NODE_CACHING

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -655,7 +655,7 @@ def test_disable_node_caching_at_pipeline_level(
     assert "components" in workflow_spec_docs[0]
     assert "platforms" in workflow_spec_docs[1]
 
-    caching_options = workflow_spec_docs[0]["root"]["dag"]["tasks"]["run-a-file"]["cachingOptions"]
+    caching_options = workflow_spec_docs[0]["root"]["dag"]["tasks"]["run-a-file"].get("cachingOptions", {})
     if disable_node_caching:
         assert caching_options == {}
     else:
@@ -750,17 +750,17 @@ def test_disable_node_caching_at_node_level(
         # - 1st task (produce a file): cache disabled since it is omitted so the value was inherited from the pipeline
         # - 2nd task (consumer-producer): cache enabled since it is explicitly enabled in the pipeline source
         # - 3rd task (consume a file): cache disabled since it is explicitly disabled in the pipeline source
-        assert tasks["run-a-file"]["cachingOptions"] == {}
-        assert tasks["run-a-file-2"]["cachingOptions"]["enableCache"] is True
-        assert tasks["run-a-file-3"]["cachingOptions"] == {}
+        assert tasks["run-a-file"].get("cachingOptions", {}) == {}
+        assert tasks["run-a-file-2"].get("cachingOptions", {}).get("enableCache") is True
+        assert tasks["run-a-file-3"].get("cachingOptions", {}) == {}
     else:
         # When Node Caching is enabled in the pipeline level, we expect:
         # - 1st task (produce a file): cache enabled since it is omitted so the value was inherited from the pipeline
         # - 2nd task (consumer-producer): cache enabled since it is explicitly enabled in the pipeline source
         # - 3rd task (consume a file): cache disabled since it is explicitly disabled in the pipeline source
-        assert tasks["run-a-file"]["cachingOptions"]["enableCache"] is True
-        assert tasks["run-a-file-2"]["cachingOptions"]["enableCache"] is True
-        assert tasks["run-a-file-3"]["cachingOptions"] == {}
+        assert tasks["run-a-file"].get("cachingOptions", {}).get("enableCache") is True
+        assert tasks["run-a-file-2"].get("cachingOptions", {}).get("enableCache") is True
+        assert tasks["run-a-file-3"].get("cachingOptions", {}) == {}
 
 
 @pytest.mark.parametrize(

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -593,7 +593,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_workflow_engine_test(
     ],
     indirect=True,
 )
-def test_disable_node_caching_on_compiled_pipeline(
+def test_disable_node_caching_at_pipeline_level(
     monkeypatch, processor: KfpPipelineProcessor, metadata_dependencies: Dict[str, Any], tmpdir
 ):
     """
@@ -660,6 +660,107 @@ def test_disable_node_caching_on_compiled_pipeline(
         assert caching_options == {}
     else:
         assert caching_options["enableCache"] is True
+
+
+@pytest.mark.parametrize(
+    "metadata_dependencies",
+    [
+        {
+            "pipeline_file": Path(__file__).parent
+            / ".."
+            / "resources"
+            / "test_pipelines"
+            / "kfp"
+            / "kfp-multi-node-generic.pipeline",
+            "workflow_engine": WorkflowEngineType.ARGO,
+            "with_disable_node_caching": True,
+        },
+        {
+            "pipeline_file": Path(__file__).parent
+            / ".."
+            / "resources"
+            / "test_pipelines"
+            / "kfp"
+            / "kfp-multi-node-generic.pipeline",
+            "workflow_engine": WorkflowEngineType.ARGO,
+            "with_disable_node_caching": False,
+        },
+    ],
+    indirect=True,
+)
+def test_disable_node_caching_at_node_level(
+    monkeypatch, processor: KfpPipelineProcessor, metadata_dependencies: Dict[str, Any], tmpdir
+):
+    """
+    This test validates the disable_node_caching option all the way to the compiled pipeline.
+    """
+
+    # Obtain artifacts from metadata_dependencies fixture
+    test_pipeline_file = metadata_dependencies["pipeline_file"]
+    pipeline = metadata_dependencies["pipeline_object"]
+    assert pipeline is not None
+    runtime_config = metadata_dependencies["runtime_config"]
+    assert runtime_config is not None
+    assert runtime_config.name == pipeline.runtime_config
+
+    disable_node_caching_pipeline_level = metadata_dependencies["fixture_parameters"]["with_disable_node_caching"]
+
+    workflow_engine = WorkflowEngineType.get_instance_by_value(runtime_config.metadata["engine"])
+
+    # Mock calls that require access to object storage, because their side effects
+    # have no bearing on the outcome of this test.
+    monkeypatch.setattr(processor, "_upload_dependencies_to_object_store", lambda w, x, y, prefix: True)
+    monkeypatch.setattr(processor, "_verify_cos_connectivity", lambda x: True)
+
+    compiled_output_file = Path(tmpdir) / test_pipeline_file.with_suffix(".yaml").name
+    compiled_output_file_name = str(compiled_output_file.absolute())
+
+    # generate Python DSL for the specified workflow engine
+    pipeline_version = f"{pipeline.name}-test-0"
+    pipeline_instance_id = f"{pipeline.name}-{datetime.now().strftime('%m%d%H%M%S')}"
+    experiment_name = f"{pipeline.name}-test-0"
+    generated_dsl = processor._generate_pipeline_dsl(
+        pipeline=pipeline,
+        pipeline_name=pipeline.name,
+        workflow_engine=workflow_engine,
+        pipeline_version=pipeline_version,
+        pipeline_instance_id=pipeline_instance_id,
+        experiment_name=experiment_name,
+    )
+
+    # Compile the generated Python DSL
+    processor._compile_pipeline_dsl(
+        dsl=generated_dsl,
+        workflow_engine=workflow_engine,
+        output_file=compiled_output_file_name,
+        pipeline_conf=None,
+    )
+
+    # Load compiled workflow
+    with open(compiled_output_file_name) as f:
+        workflow_spec_docs = list(yaml.safe_load_all(f.read()))
+
+    assert len(workflow_spec_docs) == 2
+    assert "components" in workflow_spec_docs[0]
+    assert "platforms" in workflow_spec_docs[1]
+
+    tasks = workflow_spec_docs[0]["root"]["dag"]["tasks"]
+    if disable_node_caching_pipeline_level:
+        # When Node Caching is disabled in the pipeline level, we expect:
+        # - 1st task (produce a file): cache disabled since it is omitted so the value was inherited from the pipeline
+        # - 2nd task (consumer-producer): cache enabled since it is explicitly enabled in the pipeline source
+        # - 3rd task (consume a file): cache disabled since it is explicitly disabled in the pipeline source
+        assert tasks["run-a-file"]["cachingOptions"] == {}
+        assert tasks["run-a-file-2"]["cachingOptions"]["enableCache"] is True
+        assert tasks["run-a-file-3"]["cachingOptions"] == {}
+    else:
+        # When Node Caching is enabled in the pipeline level, we expect:
+        # - 1st task (produce a file): cache enabled since it is omitted so the value was inherited from the pipeline
+        # - 2nd task (consumer-producer): cache enabled since it is explicitly enabled in the pipeline source
+        # - 3rd task (consume a file): cache disabled since it is explicitly disabled in the pipeline source
+        assert tasks["run-a-file"]["cachingOptions"]["enableCache"] is True
+        assert tasks["run-a-file-2"]["cachingOptions"]["enableCache"] is True
+        assert tasks["run-a-file-3"]["cachingOptions"] == {}
 
 
 @pytest.mark.parametrize(

--- a/elyra/tests/pipeline/resources/additional_generic_properties.json
+++ b/elyra/tests/pipeline/resources/additional_generic_properties.json
@@ -151,6 +151,15 @@
     },
     "default": []
   },
+  "disable_node_caching": {
+    "description": "Disable caching to force node re-execution in the target runtime environment.",
+    "enum": ["True", "False"],
+    "title": "Disable node caching",
+    "type": "string",
+    "uihints": {
+      "ui:placeholder": "Use runtime default"
+    }
+  },
   "env_vars": {
     "title": "Environment Variables",
     "description": "Environment variables to be set on the execution environment.",

--- a/elyra/tests/pipeline/resources/test_pipelines/kfp/kfp-multi-node-generic.pipeline
+++ b/elyra/tests/pipeline/resources/test_pipelines/kfp/kfp-multi-node-generic.pipeline
@@ -24,7 +24,8 @@
               "kubernetes_shared_mem_size": {},
               "kubernetes_tolerations": [],
               "mounted_volumes": [],
-              "filename": "consumer.ipynb"
+              "filename": "consumer.ipynb",
+              "disable_node_caching": true
             },
             "label": "consume a file",
             "ui_data": {
@@ -89,7 +90,8 @@
               "kubernetes_shared_mem_size": {},
               "kubernetes_tolerations": [],
               "mounted_volumes": [],
-              "filename": "consumer-producer.ipynb"
+              "filename": "consumer-producer.ipynb",
+              "disable_node_caching": false
             },
             "label": "",
             "ui_data": {


### PR DESCRIPTION
## Description

See https://issues.redhat.com/browse/RHOAIENG-11446

Add task-level cache control through a new dropdown in `Node Properties` > `Additional Properties`

---

## Validation

Container image for validation that includes these changes:
```
ghcr.io/caponetto/opendatahub-io-elyra/workbench-images:jupyter-trustyai-ubi9-python-3.11-20250618-aa65c62-sha-e6cae2d1
```

Need to add the following env var to the running pod:
```
KF_PIPELINES_SSL_SA_CERTS=/etc/pki/tls/custom-certs/ca-bundle.crt
```

### General setup:

1. Create 3 notebooks with any content: `A.ipynb`, `B.ipynb`, and `C.ipynb`
1. Create a pipeline: `ABC.pipeline`
1. Go to the `Pipeline Properties` tab and set the `Runtime Image` property to `Python 3.11`
1. Drag the 3 notebooks into the pipeline and connect them (A -> B -> C)

> **Note**: Test scenarios 1, 2, and 3 ensure that the previous behavior is maintained.

### **Test scenario 1**:
1. Go to the `Pipeline Properties` tab and set the `Disable node caching` to `Use runtime default`
1. Run the pipeline. Note: cache is never used when run through Elyra.
1. Access the Dashboard via the `Run Details` link and wait for the run to complete.
1. In the Dashboard, create a new Run from the pipeline you just created

Expected: 
- The cache **will** be used for all nodes since the default behavior is to use the cache

### **Test scenario 2**:
1. Go to the `Pipeline Properties` tab and set the `Disable node caching` to `True`
1. Run the pipeline. Note: cache is never used when run through Elyra.
1. Access the Dashboard via the `Run Details` link and wait for the run to complete.
1. In the Dashboard, create a new Run from the pipeline you just created

Expected: 
- The cache **will not** be used at all since it was explicitly disabled at the pipeline level

### **Test scenario 3**:
1. Go to the `Pipeline Properties` tab and set the `Disable node caching` to `False`
1. Run the pipeline. Note: cache is never used when run through Elyra.
1. Access the Dashboard via the `Run Details` link and wait for the run to complete.
1. In the Dashboard, create a new Run from the pipeline you just created

Expected: 
- The cache **will** be used for all nodes since it was explicitly enabled at the pipeline level

### **Set up for the next scenarios**:

1. Select the notebook `A.ipynb`
1. Go to the `Node Properties` tab and set the `Disable node caching` to `False`
1. Select the notebook `B.ipynb`
1. Go to the `Node Properties` tab and set the `Disable node caching` to `True`
1. Select the notebook `C.ipynb`
1. Go to the `Node Properties` tab and leave `Disable node caching` unchanged to use the pipeline default

### **Test scenario 4**:
1. Go to the `Pipeline Properties` tab and set the `Disable node caching` to `Use runtime default`
1. Run the pipeline. Note: cache is never used when run through Elyra.
1. Access the Dashboard via the `Run Details` link and wait for the run to complete.
1. In the Dashboard, create a new Run from the pipeline you just created

Expected:
- The cache **will** be used for the `A` node since it was explicitly enabled at the node level
- The cache **will not** be used for the `B` node since it was explicitly disabled at the node level
- The cache **will** be used for the `C` node since it inherited the value from the pipeline property

### **Test scenario 5**:
1. Go to the `Pipeline Properties` tab and set the `Disable node caching` to `True`
1. Run the pipeline. Note: cache is never used when run through Elyra.
1. Access the Dashboard via the `Run Details` link and wait for the run to complete.
1. In the Dashboard, create a new Run from the pipeline you just created

Expected:
- The cache **will** be used for the `A` node since it was explicitly enabled at the node level
- The cache **will not** be used for the `B` node since it was explicitly disabled at the node level
- The cache **will not** be used for the `C` node since it inherited the value from the pipeline property

### **Test scenario 6**:
1. Go to the `Pipeline Properties` tab and set the `Disable node caching` to `False`
1. Run the pipeline. Note: cache is never used when run through Elyra.
1. Access the Dashboard via the `Run Details` link and wait for the run to complete.
1. In the Dashboard, create a new Run from the pipeline you just created

Expected:
- The cache **will** be used for the `A` node since it was explicitly enabled at the node level
- The cache **will not** be used for the `B` node since it was explicitly disabled at the node level
- The cache **will** be used for the `C` node since it inherited the value from the pipeline property

> **Note**: Nodes might fail if they depend on a previous node outputs that was cached. This is out of the scope of this task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for disabling or enabling node caching at both the pipeline and individual node levels for generic components in Kubeflow Pipelines.
  - Introduced a new property to control node caching behavior, allowing users to force node re-execution if desired.

- **Bug Fixes**
  - Improved handling of the node caching property to ensure correct application based on user settings.

- **Tests**
  - Enhanced test coverage to verify node caching behavior at both pipeline and node levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->