### PR TITLE
Fix `flake8` errors in the CI

### DIFF
--- a/elyra/pipeline/properties.py
+++ b/elyra/pipeline/properties.py
@@ -29,10 +29,6 @@ from typing import Set
 from typing import TYPE_CHECKING
 from typing import Union
 
-# Prevent a circular reference by importing RuntimePipelineProcessor only during type-checking
-if TYPE_CHECKING:
-    from elyra.pipeline.processor import RuntimePipelineProcessor
-
 from elyra.pipeline.pipeline_constants import DISABLE_NODE_CACHING
 from elyra.pipeline.pipeline_constants import ENV_VARIABLES
 from elyra.pipeline.pipeline_constants import KUBERNETES_POD_ANNOTATIONS
@@ -49,6 +45,9 @@ from elyra.util.kubernetes import is_valid_kubernetes_key
 from elyra.util.kubernetes import is_valid_kubernetes_resource_name
 from elyra.util.kubernetes import is_valid_label_key
 from elyra.util.kubernetes import is_valid_label_value
+
+if TYPE_CHECKING:  # Prevent a circular reference by importing RuntimePipelineProcessor only during type-checking
+    from elyra.pipeline.processor import RuntimePipelineProcessor
 
 
 class PropertyInputType:


### PR DESCRIPTION
This PR fixes the failures in the CI after a new release of the `flake8-import-order` package.
See the [last runs](https://github.com/opendatahub-io/elyra/actions/workflows/build.yml?query=branch%3Amain).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal import organization to prevent circular references. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->