### PR TITLE
RHOAIENG-26520: On pipeline level disable caching by default

### DIFF
--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -773,6 +773,10 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                     param.name: {"pipeline_parameter_reference": param.name} for param in task_parameters
                 }
 
+                # By default disable caching for the pipeline except if user set a value (RHOAIENG-26520)
+                if "disable_node_caching" not in workflow_task["task_modifiers"].keys():
+                    workflow_task["task_modifiers"]["disable_node_caching"] = True
+
                 component_definition = generic_component_template.render(
                     container_image=operation.runtime_image,
                     task_parameters=task_parameters,

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -774,7 +774,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                 }
 
                 # By default disable caching for the pipeline except if user set a value (RHOAIENG-26520)
-                if "disable_node_caching" not in workflow_task["task_modifiers"].keys():
+                if "disable_node_caching" not in workflow_task["task_modifiers"]:
                     workflow_task["task_modifiers"]["disable_node_caching"] = True
 
                 component_definition = generic_component_template.render(

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -577,7 +577,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_workflow_engine_test(
             / "test_pipelines"
             / "kfp"
             / "kfp-one-node-generic.pipeline",
-            "workflow_engine": WorkflowEngineType.ARGO
+            "workflow_engine": WorkflowEngineType.ARGO,
         }
     ],
     indirect=True,
@@ -586,7 +586,7 @@ def test_disable_node_caching_at_pipeline_level(
     monkeypatch, processor: KfpPipelineProcessor, metadata_dependencies: Dict[str, Any], tmpdir
 ):
     """
-    This test validates the disable_node_caching option all the way to the compiled pipeline.
+    This test is to make sure that the caching is disabled at pipeline level
     By default the node caching should be false (RHOAIENG-26520)
     """
 


### PR DESCRIPTION
PR for [RHOAIENG-26520](https://issues.redhat.com/browse/RHOAIENG-26520)

This is setting the property `disable_node_caching` as `True` in nodes that were not modified by the user. This way, we make sure that caching is disabled by default at the pipeline level.

I did modify the `test_disable_node_caching_at_pipeline_level` test because it seems that it didn't make sense, so I removed the option `` and kept it just to check if the default generated caching config is correct, but it seems redundant with test `test_disable_node_caching_at_node_level` because it checks the same but on a pipeline with multiple nodes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node caching is now consistently disabled by default for generic pipeline tasks, ensuring more predictable execution behavior.

* **Tests**
  * Updated tests to reflect the default disabling of node caching, simplifying test cases and assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->