### PR TITLE
[RHOAIENG-27604] Remove misdirection from DSP runtime configuration in api endpoint placeholder

### DIFF
--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -50,7 +50,7 @@
           "format": "uri",
           "uihints": {
             "category": "Data Science Pipelines",
-            "ui:placeholder": "https://your-data-science-pipeline-service:port/pipeline"
+            "ui:placeholder": "https://your-data-science-pipeline-service:port"
           }
         },
         "public_api_endpoint": {
@@ -60,7 +60,7 @@
           "format": "uri",
           "uihints": {
             "category": "Data Science Pipelines",
-            "ui:placeholder": "https://your-data-science-pipeline-service:port/pipeline"
+            "ui:placeholder": "https://your-data-science-pipeline-service:port"
           }
         },
         "user_namespace": {


### PR DESCRIPTION
PR for [RHOAIENG-27604](https://issues.redhat.com/browse/RHOAIENG-27604)

There was a misdirection in DSP runtime configuration in api endpoint placeholder. I verified that the url with /pipeline does not work as intended.

Before:
<img width="3853" height="230" alt="Screenshot From 2025-08-04 12-58-27" src="https://github.com/user-attachments/assets/1dbf747f-ad45-454c-94f8-123cf13235c1" />


After: (tested with image ghcr.io/ada333/elyra/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.11-20250731-420f28f-sha-4eb9319f)
<img width="3853" height="230" alt="Screenshot From 2025-08-04 12-31-08" src="https://github.com/user-attachments/assets/17dc1adc-5cfa-4e04-8eac-e2999ebbd02c" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated placeholder text for API endpoint fields in the Kubeflow Pipelines configuration to provide clearer examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->