### PR TITLE
[RHOAIENG-11164] Improve error details

### DIFF
--- a/elyra/pipeline/handlers.py
+++ b/elyra/pipeline/handlers.py
@@ -82,8 +82,10 @@ def format_validation_errors_message(validation_response) -> str:
     :return: Formatted error message string
     """
     issues = validation_response.to_json().get("issues", [])
+    if not issues:
+        return "Issues found in pipeline"
     message = ""
-    
+
     for issue in issues:
         data = issue.get("data", {})
         node_name = data.get("nodeName")

--- a/elyra/pipeline/handlers.py
+++ b/elyra/pipeline/handlers.py
@@ -74,6 +74,27 @@ def get_runtime_processor_type(runtime_type: str, log: Logger, request_path: str
     return None
 
 
+def format_validation_errors_message(validation_response) -> str:
+    """
+    Format validation errors into a readable message.
+
+    :param validation_response: ValidationResponse object containing validation issues
+    :return: Formatted error message string
+    """
+    issues = validation_response.to_json().get("issues", [])
+    message = ""
+    
+    for issue in issues:
+        data = issue.get("data", {})
+        node_name = data.get("nodeName")
+        if node_name:
+            message += f"Node: {node_name}\n"
+        message += issue.get("message", "Unknown error") + "\n" + "\n"
+    if message:
+        message = message[:-2]
+    return message
+
+
 class PipelineExportHandler(HttpErrorMixin, APIHandler):
     """Handler to expose REST API to export pipelines"""
 
@@ -117,7 +138,7 @@ class PipelineExportHandler(HttpErrorMixin, APIHandler):
             json_msg = json.dumps(
                 {
                     "reason": responses.get(400),
-                    "message": "Errors found in pipeline",
+                    "message": format_validation_errors_message(response),
                     "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                     "issues": response.to_json().get("issues"),
                 }
@@ -164,7 +185,7 @@ class PipelineSchedulerHandler(HttpErrorMixin, APIHandler):
             json_msg = json.dumps(
                 {
                     "reason": responses.get(400),
-                    "message": "Errors found in pipeline",
+                    "message": format_validation_errors_message(response),
                     "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                     "issues": response.to_json().get("issues"),
                 }

--- a/packages/ui-components/src/ExpandableErrorDialog.tsx
+++ b/packages/ui-components/src/ExpandableErrorDialog.tsx
@@ -19,6 +19,7 @@ import * as React from 'react';
 import { ExpandableComponent } from './ExpandableComponent';
 
 const MESSAGE_DISPLAY = 'elyra-errorDialog-messageDisplay';
+const MESSAGE_CONTAINER = 'elyra-errorDialog-messageContainer';
 const ERROR_DIALOG_WIDTH = 600;
 const ERROR_DIALOG_HEIGHT = 400;
 const JP_DIALOG_CONTENT = 'jp-Dialog-content';
@@ -71,7 +72,7 @@ export const ExpandableErrorDialog: React.FC<IErrorDialogProps> = ({
 
   return (
     <div className={MESSAGE_DISPLAY}>
-      <div>{message}</div>
+      <div className={MESSAGE_CONTAINER}>{message}</div>
       {traceback ? (
         <ExpandableComponent
           displayName="Error details: "
@@ -81,7 +82,9 @@ export const ExpandableErrorDialog: React.FC<IErrorDialogProps> = ({
           <pre>{traceback}</pre>
         </ExpandableComponent>
       ) : null}
-      <div>{defaultMessage}</div>
+      <div>
+        <strong>{defaultMessage}</strong>
+      </div>
     </div>
   );
 };

--- a/packages/ui-components/style/index.css
+++ b/packages/ui-components/style/index.css
@@ -97,10 +97,10 @@
 
 .elyra-errorDialog-messageDisplay pre {
   min-height: 125px;
-  height: 100%;
-  width: 100%;
   resize: none;
-  overflow-x: scroll;
+  height: auto;
+  width: auto;
+  overflow: visible;
 }
 
 .elyra-errorDialog-messageDisplay {
@@ -117,6 +117,22 @@
   flex: 1;
   min-height: 0px;
   flex-direction: column;
+}
+
+.elyra-errorDialog-messageContainer {
+  max-height: 200px;
+  overflow-y: auto;
+  overflow-x: auto;
+  padding: 5px;
+  margin: 5px;
+  border: 1px solid var(--jp-border-color2);
+  border-radius: 2px;
+  color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color1);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--jp-code-font-family);
+  font-size: var(--jp-code-font-size);
 }
 
 /* temporary fix until this is addressed in jupyterlab */


### PR DESCRIPTION
PR for [RHOAIENG-11164](https://issues.redhat.com/browse/RHOAIENG-11164)

I edited the error log to be more readable, so that the error messages are displayed and user doesn´t have to look for them in JSON.

Changes I made:

1. more detailed error message visible at first look (I was trying to make styling similar to error details)
2. added scrollbar for this error message
3. removed double scrollbar from error details (there was a double scrollbar if error details were not big enough)
4. made the text "Check the Jupyterlab log for more details" (text at the end) bold for better visibility


Before:
<img width="500" height="600" alt="Screenshot From 2025-08-07 15-13-01" src="https://github.com/user-attachments/assets/03839957-d92e-4ff8-93ad-f34596e399d3" />


After:
<img width="1490" height="781" alt="Screenshot From 2025-08-13 14-20-54" src="https://github.com/user-attachments/assets/38cb1c43-8882-455f-9366-9c97adf637d8" />


Double scrollbar in error details:
<img width="1587" height="643" alt="Screenshot From 2025-08-11 10-26-56" src="https://github.com/user-attachments/assets/b54361c5-7caa-4d09-8818-efa936c05ba8" />


Possible improvements:

1. Add headline for the error message (something like: "Errors found when verifying pipeline: ")
2. Colors to help illustrate severity



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors now display detailed, per-issue messages (including the affected node when available) instead of a generic message across validation endpoints.
  * Messages are formatted with clear separation between issues and no trailing blank lines.
  * Existing fields in error responses, such as the timestamp and issues list, remain unchanged.
  * Applies to all validation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->