### PR TITLE
RHOAIENG-32631: Rename Data Science Pipelines to AI Pipelines

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -147,7 +147,7 @@ Cypress.Commands.add(
       switch (type) {
         case 'kfp':
           cy.get(
-            '.jp-LauncherCard[data-category="Elyra"][title="Data Science Pipeline Editor"]'
+            '.jp-LauncherCard[data-category="Elyra"][title="AI Pipeline Editor"]'
           ).click();
           break;
         case 'airflow':

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -68,7 +68,7 @@ Cypress.Commands.add('createRuntimeConfig', ({ type } = {}): void => {
   cy.findByLabelText(/^display name/i).type(`${type} Test Runtime`);
 
   if (type === 'kfp') {
-    cy.findByLabelText(/data science .* endpoint\*/i).type(
+    cy.findByLabelText(/ai .* endpoint\*/i).type(
       'https://kubernetes-service.ibm.com/pipeline'
     );
   } else {

--- a/cypress/tests/launcher.cy.ts
+++ b/cypress/tests/launcher.cy.ts
@@ -37,7 +37,7 @@ describe('Elyra launcher is in use', () => {
     //   '.jp-LauncherCard[data-category="Elyra"][title="Apache Airflow Pipeline Editor"]:visible'
     // );
     cy.get(
-      '.jp-LauncherCard[data-category="Elyra"][title="Data Science Pipeline Editor"]:visible'
+      '.jp-LauncherCard[data-category="Elyra"][title="AI Pipeline Editor"]:visible'
     );
     // Script editor extension is available
     cy.get(

--- a/cypress/tests/pipeline.cy.ts
+++ b/cypress/tests/pipeline.cy.ts
@@ -895,7 +895,7 @@ describe('Pipeline Editor tests', () => {
 
   it('kfp pipeline toolbar should display expected runtime', () => {
     cy.createPipeline({ type: 'kfp' });
-    cy.get('.toolbar-icon-label').contains(/runtime: data science pipelines/i);
+    cy.get('.toolbar-icon-label').contains(/runtime: ai pipelines/i);
   });
 
   it.skip('airflow pipeline toolbar should display expected runtime (Airflow is not part of ODH distribution)', () => {

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://raw.githubusercontent.com/elyra-ai/elyra/main/elyra/metadata/schemas/meta-schema.json",
   "$id": "https://raw.githubusercontent.com/elyra-ai/elyra/main/elyra/metadata/schemas/kfp.json",
-  "title": "Data Science Pipelines",
+  "title": "AI Pipelines",
   "name": "kfp",
   "schemaspace": "runtimes",
   "schemaspace_id": "130b8e00-de7c-4b32-b553-b4a52824a3b5",
   "metadata_class_name": "elyra.pipeline.kfp.kfp_metadata.KfpMetadata",
   "runtime_type": "KUBEFLOW_PIPELINES",
   "uihints": {
-    "title": "Data Science Pipelines runtimes",
+    "title": "AI Pipelines runtimes",
     "icon": "elyra:runtimes",
     "reference_url": "https://elyra.readthedocs.io/en/latest/user_guide/runtime-conf.html"
   },
@@ -21,7 +21,7 @@
     },
     "display_name": {
       "title": "Display Name",
-      "description": "Display name of this Data Science Pipelines configuration",
+      "description": "Display name of this AI Pipelines configuration",
       "type": "string",
       "minLength": 1
     },
@@ -40,47 +40,47 @@
         },
         "description": {
           "title": "Description",
-          "description": "Description of this Data Science Pipelines configuration",
+          "description": "Description of this AI Pipelines configuration",
           "type": "string"
         },
         "api_endpoint": {
-          "title": "Data Science Pipelines API Endpoint",
-          "description": "The Data Science Pipelines API endpoint",
+          "title": "AI Pipelines API Endpoint",
+          "description": "The AI Pipelines API endpoint",
           "type": "string",
           "format": "uri",
           "uihints": {
-            "category": "Data Science Pipelines",
-            "ui:placeholder": "https://your-data-science-pipeline-service:port"
+            "category": "AI Pipelines",
+            "ui:placeholder": "https://your-ai-pipeline-service:port"
           }
         },
         "public_api_endpoint": {
-          "title": "Public Data Science Pipelines API Endpoint",
-          "description": "The public Data Science Pipelines API endpoint",
+          "title": "Public AI Pipelines API Endpoint",
+          "description": "The public AI Pipelines API endpoint",
           "type": "string",
           "format": "uri",
           "uihints": {
-            "category": "Data Science Pipelines",
-            "ui:placeholder": "https://your-data-science-pipeline-service:port"
+            "category": "AI Pipelines",
+            "ui:placeholder": "https://your-ai-pipeline-service:port"
           }
         },
         "user_namespace": {
-          "title": "Data Science Pipelines User Namespace",
-          "description": "The Data Science Pipelines user namespace used to create experiments",
+          "title": "AI Pipelines User Namespace",
+          "description": "The AI Pipelines user namespace used to create experiments",
           "type": "string",
           "pattern": "^[a-z0-9][-a-z0-9]*[a-z0-9]$",
           "maxLength": 63,
           "uihints": {
-            "category": "Data Science Pipelines"
+            "category": "AI Pipelines"
           }
         },
         "engine": {
-          "title": "Data Science Pipelines engine",
-          "description": "The Data Science Pipelines engine in use",
+          "title": "AI Pipelines engine",
+          "description": "The AI Pipelines engine in use",
           "type": "string",
           "enum": ["Argo"],
           "default": "Argo",
           "uihints": {
-            "category": "Data Science Pipelines"
+            "category": "AI Pipelines"
           }
         },
         "auth_type": {
@@ -90,24 +90,24 @@
           "enum": ["{AUTH_PROVIDER_PLACEHOLDERS}"],
           "default": "{DEFAULT_AUTH_PROVIDER_PLACEHOLDER}",
           "uihints": {
-            "category": "Data Science Pipelines"
+            "category": "AI Pipelines"
           }
         },
         "api_username": {
-          "title": "Data Science Pipelines API Endpoint Username",
-          "description": "The Data Science Pipelines API endpoint username. This property is required for all authentication types, except NO_AUTHENTICATION and KUBERNETES_SERVICE_ACCOUNT_TOKEN.",
+          "title": "AI Pipelines API Endpoint Username",
+          "description": "The AI Pipelines API endpoint username. This property is required for all authentication types, except NO_AUTHENTICATION and KUBERNETES_SERVICE_ACCOUNT_TOKEN.",
           "type": "string",
           "uihints": {
-            "category": "Data Science Pipelines"
+            "category": "AI Pipelines"
           }
         },
         "api_password": {
-          "title": "Data Science Pipelines API Endpoint Password Or Token",
+          "title": "AI Pipelines API Endpoint Password Or Token",
           "description": "Password or token to be used for authentication. This property is required for all authentication types, except NO_AUTHENTICATION and KUBERNETES_SERVICE_ACCOUNT_TOKEN.",
           "type": "string",
           "uihints": {
             "ui:field": "@elyra/metadata-extension:plugin.password",
-            "category": "Data Science Pipelines"
+            "category": "AI Pipelines"
           }
         },
         "cos_endpoint": {
@@ -184,7 +184,7 @@
         },
         "tags": {
           "title": "Tags",
-          "description": "Tags for categorizing Data Science Pipelines",
+          "description": "Tags for categorizing AI Pipelines",
           "uniqueItems": true,
           "type": "array",
           "items": {

--- a/elyra/pipeline/runtime_type.py
+++ b/elyra/pipeline/runtime_type.py
@@ -33,7 +33,7 @@ class RuntimeProcessorType(Enum):
     """
 
     LOCAL = "Local"
-    KUBEFLOW_PIPELINES = "Data Science"
+    KUBEFLOW_PIPELINES = "AI"
     APACHE_AIRFLOW = "Apache Airflow"
     ARGO = "Argo"
     ######################################

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_with_supernode.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_with_supernode.json
@@ -105,7 +105,7 @@
           "type": "execution_node",
           "op": "execute-notebook-node",
           "app_data": {
-            "label": "data_science_aws",
+            "label": "ai_aws",
             "component_parameters": {
               "filename": "demo-pipelines/data_science_aws.ipynb",
               "runtime_image": "elyra/tensorflow:1.15.2-py3",
@@ -113,7 +113,7 @@
               "include_subdirectories": false
             },
             "ui_data": {
-              "label": "data_science_aws",
+              "label": "ai_aws",
               "image": "useDefaultIcon",
               "x_pos": 814.85107421875,
               "y_pos": 104.74483108520508,

--- a/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
+++ b/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
@@ -76,7 +76,7 @@ class ComponentCatalogsDisplay extends MetadataDisplay<IMetadataDisplayProps> {
     return (
       <div>
         <h6>Runtime Type</h6>
-        {'DATA_SCIENCE_PIPELINES'}
+        {'AI_PIPELINES'}
         <br />
         <br />
         <h6>Description</h6>


### PR DESCRIPTION
This PR addresses the renaming from `Data Science Pipelines` to `AI Pipelines` in Elyra.

I have verified this change in the UI. 

Once the reviewer has approved, I will squash the commits before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Rebranded “Data Science Pipelines” to “AI Pipelines” across the UI (labels, runtime display, launcher card, component catalog, sample pipeline node).
  - Runtime toolbar now shows “runtime: ai pipelines”.
- Documentation
  - Configuration schema titles, descriptions, and placeholders updated to “AI Pipelines”.
- Tests
  - Updated test selectors and assertions to match the new UI labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->