### PR TITLE
feat: update run URL format to point to Dashboard's external route

### DIFF
--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -422,7 +422,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
 
             self.log_pipeline_info(
                 pipeline_name,
-                f"pipeline submitted: {public_api_endpoint}/{experiment.experiment_id}/runs/{run.run_id}",
+                f"pipeline submitted: {public_api_endpoint}/runs/{run.run_id}",
                 duration=time.time() - t0,
             )
 
@@ -438,7 +438,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
 
         return KfpPipelineProcessorResponse(
             run_id=run.run_id,
-            run_url=f"{public_api_endpoint}/{experiment.experiment_id}/runs/{run.run_id}",
+            run_url=f"{public_api_endpoint}/runs/{run.run_id}",
             object_storage_url=object_storage_url,
             object_storage_path=object_storage_path,
         )


### PR DESCRIPTION
See https://issues.redhat.com/browse/RHOAIENG-34311

**Note**: This is compatible with ODH 2.35 / RHOAI 2.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Kubeflow Pipelines run links in logs and outputs to use a simplified URL without the experiment ID, ensuring links reliably open the run details page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->