### PR TITLE
RHOAIENG-18582: Making package installation optional

### DIFF
--- a/elyra/airflow/bootstrapper.py
+++ b/elyra/airflow/bootstrapper.py
@@ -45,6 +45,11 @@ enable_pipeline_info = os.getenv("ELYRA_ENABLE_PIPELINE_INFO", "true").lower() =
 enable_generic_node_script_output_to_s3 = (
     os.getenv("ELYRA_GENERIC_NODES_ENABLE_SCRIPT_OUTPUT_TO_S3", "true").lower() == "true"
 )
+# Set it to false to disable automatic package installation.
+# This is useful in airgapped environments where the image
+# already contains the required packages.
+install_packages = os.getenv("ELYRA_INSTALL_PACKAGES", "true").lower() == "true"
+
 pipeline_name = None  # global used in formatted logging
 operation_name = None  # global used in formatted logging
 
@@ -587,7 +592,8 @@ def main():
     # must be commented out in airgapped images if packages from
     # https://github.com/elyra-ai/elyra/blob/main/etc/generic/requirements-elyra.txt
     # already installed via central pip env during container build
-    OpUtil.package_install()
+    if install_packages:
+        OpUtil.package_install()
 
     # Create the appropriate instance, process dependencies and execute the operation
     file_op = FileOpBase.get_instance(**input_params)

--- a/elyra/kfp/bootstrapper.py
+++ b/elyra/kfp/bootstrapper.py
@@ -51,6 +51,11 @@ enable_pipeline_info = os.getenv("ELYRA_ENABLE_PIPELINE_INFO", "true").lower() =
 enable_generic_node_script_output_to_s3 = (
     os.getenv("ELYRA_GENERIC_NODES_ENABLE_SCRIPT_OUTPUT_TO_S3", "true").lower() == "true"
 )
+# Set it to false to disable automatic package installation.
+# This is useful in airgapped environments where the image
+# already contains the required packages.
+install_packages = os.getenv("ELYRA_INSTALL_PACKAGES", "true").lower() == "true"
+
 pipeline_name = None  # global used in formatted logging
 operation_name = None  # global used in formatted logging
 
@@ -771,7 +776,8 @@ def main():
     # must be commented out in airgapped images if packages from
     # https://github.com/elyra-ai/elyra/blob/main/etc/generic/requirements-elyra.txt
     # already installed via central pip env during container build
-    OpUtil.package_install(user_volume_path=input_params.get("user-volume-path"))
+    if install_packages:
+        OpUtil.package_install(user_volume_path=input_params.get("user-volume-path"))
 
     # Create the appropriate instance, process dependencies and execute the operation
     file_op = FileOpBase.get_instance(**input_params)


### PR DESCRIPTION
In this PR we are adding a bootstrap switch for making it optional for installing the packages. Setting it to false will consider that the packages were already installed in the environment where Elyra is running.

Currently we can achieve this by replacing the bootstrapper.py with a custom one just to remove the package installation line.

With this change we hope to avoid the need of copying this file and change the package install behavior by setting the system property ELYRA_INSTALL_PACKAGES to false.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable flag (ELYRA_INSTALL_PACKAGES) to enable or disable runtime package installation.
  * Default behavior unchanged: packages are installed automatically unless the flag is set to “false”.
  * Package installation is now skipped when disabled for both Airflow and KFP bootstrap flows.
  * Added inline guidance to help configure restricted or airgapped environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->