### PR TITLE
Cherry-pick improvements from upstream to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ help:
 purge:
 	rm -rf build *.egg-info yarn-error.log
 	rm -rf node_modules lib dist
+	rm -rf $$(find labextension -name labextensions -type d)
 	rm -rf $$(find packages -name node_modules -type d -maxdepth 2)
 	rm -rf $$(find packages -name dist -type d)
 	rm -rf $$(find packages -name lib -type d)

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,3 +1,3 @@
-jupyterlab==4.2.5
+jupyterlab~=4.4
 jupyter-packaging>=0.10
 build

--- a/create-release.py
+++ b/create-release.py
@@ -56,13 +56,23 @@ class UpdateVersionException(Exception):
 
 
 def check_run(args, cwd=os.getcwd(), capture_output=True, env=None, shell=False) -> subprocess.CompletedProcess:
+    """Run a command and return the response"""
     try:
-        return subprocess.run(args, cwd=cwd, capture_output=capture_output, check=True)
+        return subprocess.run(args, cwd=cwd, capture_output=capture_output, check=True, env=env, shell=shell)
     except subprocess.CalledProcessError as ex:
-        raise RuntimeError(f'Error executing process: {ex.stderr.decode("unicode_escape")}') from ex
+        # Safely extract error message
+        if ex.stderr is None:
+            error_msg = "No error output available"
+        elif isinstance(ex.stderr, bytes):
+            error_msg = ex.stderr.decode("utf-8", errors="replace")
+        else:
+            error_msg = str(ex.stderr)
+
+        raise RuntimeError(f"Error executing process: {error_msg}") from ex
 
 
 def check_output(args, cwd=os.getcwd(), env=None, shell=False) -> str:
+    """Run a command and return its output"""
     response = check_run(args, cwd, capture_output=True, env=env, shell=shell)
     return response.stdout.decode("utf-8").replace("\n", "")
 
@@ -71,23 +81,60 @@ def dependency_exists(command) -> bool:
     """Returns true if a command exists on the system"""
     try:
         check_run(["which", command])
-    except subprocess.CalledProcessError:
+    except RuntimeError:
         return False
 
     return True
 
 
 def sed(file: str, pattern: str, replace: str) -> None:
-    """Perform regex substitution on a given file"""
+    """Perform regex substitution on a given file using Python instead of shell commands"""
     try:
-        if sys.platform in ["linux", "linux2"]:
-            check_run(["sed", "-i", "-e", f"s#{pattern}#{replace}#g", file], capture_output=False)
-        elif sys.platform == "darwin":
-            check_run(["sed", "-i", "", "-e", f"s#{pattern}#{replace}#g", file], capture_output=False)
-        else:  # windows, other
-            raise RuntimeError(f"Current operating system not supported for release publishing: {sys.platform}: ")
+        # Validate file path
+        if not os.path.exists(file):
+            raise RuntimeError(f"File does not exist: {file}")
+
+        # Read file content
+        with open(file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Perform regex substitution with MULTILINE flag for ^ and $ anchors
+        modified_content = re.sub(pattern, replace, content, flags=re.MULTILINE)
+
+        # Write back only if content changed
+        if modified_content != content:
+            with open(file, "w", encoding="utf-8") as f:
+                f.write(modified_content)
+            print(f"Updated {file}: {pattern} -> {replace}")
+        else:
+            print(f"No changes needed in {file} for pattern: {pattern}")
+
     except Exception as ex:
-        raise RuntimeError(f"Error processing updated to file {file}: ") from ex
+        raise RuntimeError(f"Error processing file {file}: {str(ex)}") from ex
+
+
+def sed_remove(file: str, pattern: str) -> None:
+    """Remove lines matching pattern from a file using Python instead of shell commands"""
+    try:
+        # Validate file path
+        if not os.path.exists(file):
+            # Silently return if file doesn't exist (common case for install.json)
+            return
+
+        # Read file content
+        with open(file, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+
+        # Filter out lines matching pattern
+        filtered_lines = [line for line in lines if not re.search(pattern, line)]
+
+        # Write back only if content changed
+        if len(filtered_lines) != len(lines):
+            with open(file, "w", encoding="utf-8") as f:
+                f.writelines(filtered_lines)
+
+    except Exception as ex:
+        raise RuntimeError(f"Error processing file {file}: {str(ex)}") from ex
 
 
 def validate_dependencies() -> None:
@@ -117,10 +164,22 @@ def update_version_to_release() -> None:
 
     try:
         # Update backend version
-        sed(_source(".bumpversion.cfg"), rf"^current_version* =* {old_version}", f"current_version = {new_version}")
-        sed(_source("elyra/_version.py"), rf'^__version__* =* "{old_version}"', f'__version__ = "{new_version}"'),
-        sed(_source("README.md"), rf"elyra {old_version}", f"elyra {new_version}")
-        sed(_source("docs/source/getting_started/installation.md"), rf"elyra {old_version}", f"elyra {new_version}")
+        sed(
+            _source(".bumpversion.cfg"),
+            rf"^current_version\s*=\s*{re.escape(old_version)}",
+            f"current_version = {new_version}",
+        )
+        sed(
+            _source("elyra/_version.py"),
+            rf'^__version__\s*=\s*"{re.escape(old_version)}"',
+            f'__version__ = "{new_version}"',
+        )
+        sed(_source("README.md"), rf"elyra {re.escape(old_version)}", f"elyra {new_version}")
+        sed(
+            _source("docs/source/getting_started/installation.md"),
+            rf"elyra {re.escape(old_version)}",
+            f"elyra {new_version}",
+        )
 
         # Update docker related tags
         sed(_source("Makefile"), r"^TAG:=dev", f"TAG:={new_version}")
@@ -132,18 +191,20 @@ def update_version_to_release() -> None:
         sed(_source("docs/source/recipes/using-elyra-with-kubeflow-notebook-server.md"), r"main", f"{new_version}")
 
         # Update UI component versions
-        sed(_source("README.md"), rf"v{old_npm_version}", f"v{new_version}")
-        sed(_source("docs/source/getting_started/installation.md"), rf"v{old_npm_version}", f"v{new_version}")
+        sed(_source("README.md"), rf"v{re.escape(old_npm_version)}", f"v{new_version}")
+        sed(
+            _source("docs/source/getting_started/installation.md"), rf"v{re.escape(old_npm_version)}", f"v{new_version}"
+        )
 
         sed(
             _source("packages/theme/src/index.ts"),
-            r"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
         )
 
         sed(
             _source("packages/theme/src/index.ts"),
-            r"https://github.com/elyra-ai/elyra/releases/latest/",
+            re.escape("https://github.com/elyra-ai/elyra/releases/latest/"),
             rf"https://github.com/elyra-ai/elyra/releases/v{new_version}/",
         )
 
@@ -155,26 +216,26 @@ def update_version_to_release() -> None:
 
         sed(
             _source("elyra/cli/pipeline_app.py"),
-            r"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
         )
 
         # Update documentation version for elyra-metadata cli help
         sed(
             _source("elyra/metadata/metadata_app_utils.py"),
-            r"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
         )
 
         sed(
             _source("packages/pipeline-editor/src/EmptyPipelineContent.tsx"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("packages/pipeline-editor/src/PipelineEditorWidget.tsx"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
@@ -182,50 +243,50 @@ def update_version_to_release() -> None:
         # located in elyra/metadata/schemas/
         sed(
             _source("elyra/metadata/schemas/url-catalog.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/local-directory-catalog.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/local-file-catalog.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/airflow.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/kfp.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/code-snippet.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/runtime-image.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         # Update documentation references in documentation
         sed(
             _source("docs/source/user_guide/jupyterlab-interface.md"),
-            r"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
         )
 
@@ -235,27 +296,48 @@ def update_version_to_release() -> None:
             r"elyra-ai/elyra/main/etc/kfp/pip.conf",
             rf"elyra-ai/elyra/v{new_version}/etc/kfp/pip.conf",
         )
+
         sed(
             _source("docs/source/recipes/running-elyra-in-air-gapped-environment.md"),
             r"elyra-ai/elyra/main/elyra/kfp/bootstrapper.py",
             rf"elyra-ai/elyra/v{new_version}/elyra/kfp/bootstrapper.py",
         )
+
         sed(
             _source("docs/source/recipes/running-elyra-in-air-gapped-environment.md"),
             r"elyra-ai/elyra/main/elyra/airflow/bootstrapper.py",
             rf"elyra-ai/elyra/v{new_version}/elyra/airflow/bootstrapper.py",
         )
+
         sed(
             _source("docs/source/recipes/running-elyra-in-air-gapped-environment.md"),
             r"elyra-ai/elyra/main/etc/generic/requirements-elyra.txt",
             rf"elyra-ai/elyra/v{new_version}/etc/generic/requirements-elyra.txt",
         )
 
-        check_run(
-            ["lerna", "version", new_npm_version, "--no-git-tag-version", "--no-push", "--yes", "--exact"],
-            cwd=config.source_dir,
+        # UI packages
+        sed(
+            _source("lerna.json"),
+            rf"{old_npm_version}",
+            rf"{new_npm_version}",
         )
-        check_run(["yarn", "version", "--new-version", new_npm_version, "--no-git-tag-version"], cwd=config.source_dir)
+        sed(
+            _source("package.json"),
+            rf"{old_npm_version}",
+            rf"{new_npm_version}",
+        )
+
+        packages_dir = os.path.join(config.source_dir, "packages")
+        if os.path.exists(packages_dir) and os.path.isdir(packages_dir):
+            for dir in os.listdir(packages_dir):
+                dir_path = os.path.join(packages_dir, dir)
+                if os.path.isdir(dir_path):
+                    file_path = os.path.join(dir_path, "package.json")
+                    if os.path.exists(file_path):
+                        sed(file_path, re.escape(old_npm_version), new_npm_version)
+                    file_path = os.path.join(dir_path, "install.json")
+                    if os.path.exists(file_path):
+                        sed_remove(file_path, rf"packageManager")
 
     except Exception as ex:
         raise UpdateVersionException from ex
@@ -266,14 +348,27 @@ def update_version_to_dev() -> None:
 
     new_version = config.new_version
     dev_version = config.dev_version
+    new_npm_version = config.new_npm_version
     dev_npm_version = config.dev_npm_version
 
     try:
         # Update backend version
-        sed(_source(".bumpversion.cfg"), rf"^current_version* =* {new_version}", f"current_version = {dev_version}")
-        sed(_source("elyra/_version.py"), rf'^__version__* =* "{new_version}"', f'__version__ = "{dev_version}"')
-        sed(_source("README.md"), rf"elyra {new_version}", f"elyra {dev_version}")
-        sed(_source("docs/source/getting_started/installation.md"), rf"elyra {new_version}", f"elyra {dev_version}")
+        sed(
+            _source(".bumpversion.cfg"),
+            rf"^current_version\s*=\s*{re.escape(new_version)}",
+            f"current_version = {dev_version}",
+        )
+        sed(
+            _source("elyra/_version.py"),
+            rf'^__version__\s*=\s*"{re.escape(new_version)}"',
+            f'__version__ = "{dev_version}"',
+        )
+        sed(_source("README.md"), rf"elyra {re.escape(new_version)}", f"elyra {dev_version}")
+        sed(
+            _source("docs/source/getting_started/installation.md"),
+            rf"elyra {re.escape(new_version)}",
+            f"elyra {dev_version}",
+        )
 
         # Update docker related tags
         sed(_source("Makefile"), rf"^TAG:={new_version}", "TAG:=dev")
@@ -295,13 +390,13 @@ def update_version_to_dev() -> None:
         sed(
             _source("packages/theme/src/index.ts"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
-            rf"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
         )
 
         sed(
             _source("packages/theme/src/index.ts"),
             rf"https://github.com/elyra-ai/elyra/releases/v{new_version}/",
-            rf"https://github.com/elyra-ai/elyra/releases/latest/",
+            re.escape("https://github.com/elyra-ai/elyra/releases/latest/"),
         )
 
         sed(
@@ -314,32 +409,32 @@ def update_version_to_dev() -> None:
         sed(
             _source("docs/source/user_guide/jupyterlab-interface.md"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
-            r"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
         )
 
         sed(
             _source("elyra/cli/pipeline_app.py"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
-            rf"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
         )
 
         # Update documentation version for elyra-metadata cli help
         sed(
             _source("elyra/metadata/metadata_app_utils.py"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
-            rf"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
         )
 
         sed(
             _source("packages/pipeline-editor/src/EmptyPipelineContent.tsx"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("packages/pipeline-editor/src/PipelineEditorWidget.tsx"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         # Update GitHub references in documentation
@@ -369,59 +464,87 @@ def update_version_to_dev() -> None:
         sed(
             _source("elyra/metadata/schemas/url-catalog.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/local-directory-catalog.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/local-file-catalog.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/airflow.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/kfp.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/code-snippet.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/runtime-image.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
-        check_run(
-            ["lerna", "version", dev_npm_version, "--no-git-tag-version", "--no-push", "--yes", "--exact"],
-            cwd=config.source_dir,
+        sed(
+            _source("lerna.json"),
+            rf"{new_npm_version}",
+            rf"{dev_npm_version}",
         )
-        check_run(["yarn", "version", "--new-version", dev_npm_version, "--no-git-tag-version"], cwd=config.source_dir)
+
+        sed(
+            _source("package.json"),
+            rf"{new_npm_version}",
+            rf"{dev_npm_version}",
+        )
+
+        packages_dir = os.path.join(config.source_dir, "packages")
+        if os.path.exists(packages_dir) and os.path.isdir(packages_dir):
+            for dir in os.listdir(packages_dir):
+                dir_path = os.path.join(packages_dir, dir)
+                if os.path.isdir(dir_path):
+                    file_path = os.path.join(dir_path, "package.json")
+                    if os.path.exists(file_path):
+                        sed(file_path, re.escape(new_npm_version), dev_npm_version)
 
     except Exception as ex:
         raise UpdateVersionException from ex
 
 
 def _source(file: str) -> str:
+    """Get absolute path for a file within the source directory with path validation"""
     global config
 
-    return os.path.join(config.source_dir, file)
+    # Validate input
+    if not file or ".." in file or file.startswith("/"):
+        raise ValueError(f"Invalid file path: {file}")
+
+    # Create absolute path
+    source_path = os.path.abspath(config.source_dir)
+    file_path = os.path.abspath(os.path.join(source_path, file))
+
+    # Ensure the resolved path is within source directory (prevent path traversal)
+    if not file_path.startswith(source_path + os.sep) and file_path != source_path:
+        raise ValueError(f"Path traversal attempt detected: {file}")
+
+    return file_path
 
 
 def checkout_code() -> None:
@@ -434,6 +557,10 @@ def checkout_code() -> None:
     print(f"Cloning repository: {config.git_url}")
     if os.path.exists(config.work_dir):
         print(f"Removing working directory: {config.work_dir}")
+        # Validate work_dir path to prevent accidental deletion
+        work_dir_abs = os.path.abspath(config.work_dir)
+        if not work_dir_abs.endswith(("/build/release", "\\build\\release")) or len(work_dir_abs.split(os.sep)) < 3:
+            raise ValueError(f"Unsafe work directory path: {work_dir_abs}")
         shutil.rmtree(config.work_dir)
     print(f"Creating working directory: {config.work_dir}")
     os.makedirs(config.work_dir)
@@ -453,6 +580,7 @@ def build_release():
     print("-----------------------------------------------------------------")
 
     # Build wheels and source packages
+    print(f">>> Building release in {config.source_dir}")
     check_run(["make", "release"], cwd=config.source_dir, capture_output=False)
 
     if not config.pre_release:
@@ -505,11 +633,27 @@ def show_release_artifacts():
     print("")
 
 
+def update_yarn_lock():
+    global config
+
+    print("-----------------------------------------------------------------")
+    print("----------------------- Update Yarn lock ------------------------")
+    print("-----------------------------------------------------------------")
+
+    # Build wheels and source packages
+    print(f">>> Updating yarn lock file in {config.source_dir}")
+    check_run(["yarn", "install"], cwd=config.source_dir, capture_output=False)
+
+    print("")
+
+
 def copy_extension_dir(extension: str, work_dir: str) -> None:
     global config
 
-    extension_package_source_dir = os.path.join(config.source_dir, "build/labextensions/@elyra", extension)
-    extension_package_dest_dir = os.path.join(work_dir, "build/labextensions/@elyra", extension)
+    extension = extension.replace("-", "_")
+    extension_package_source_dir = os.path.join(config.source_dir, f"labextensions/elyra_{extension}")
+    extension_package_dest_dir = os.path.join(work_dir, f"labextensions/elyra_{extension}")
+    print(f">>> Copying extension package from {extension_package_source_dir} to {extension_package_dest_dir}")
     os.makedirs(os.path.dirname(extension_package_dest_dir), exist_ok=True)
     shutil.copytree(extension_package_source_dir, extension_package_dest_dir)
 
@@ -520,6 +664,7 @@ def generate_changelog() -> None:
     print("-----------------------------------------------------------------")
     print("--------------------- Preparing Changelog -----------------------")
     print("-----------------------------------------------------------------")
+    print("")
 
     changelog_path = os.path.join(config.source_dir, "docs/source/getting_started/changelog.md")
     changelog_backup_path = os.path.join(config.source_dir, "docs/source/getting_started/changelog.bak")
@@ -562,9 +707,9 @@ def generate_changelog() -> None:
                 # print(f'>>> {commit_hash} - {commit_title}')
                 if commit_title != "Prepare for next development iteration":
                     pr_string = ""
-                    pr = re.findall("\(#(.*?)\)", commit_title)
+                    pr = re.findall(r"\(#(.*?)\)", commit_title)
                     if pr:
-                        commit_title = re.sub("\(#(.*?)\)", "", commit_title).strip()
+                        commit_title = re.sub(r"\(#(.*?)\)", "", commit_title).strip()
                         pr_string = f" - [#{pr[0]}](https://github.com/elyra-ai/elyra/pull/{pr[0]})"
                     changelog_entry = f"- {commit_title}{pr_string}\n"
                     changelog.write(changelog_entry)
@@ -638,7 +783,12 @@ def prepare_extensions_release() -> None:
         print(f"Preparing extension : {extension} at {extension_source_dir}")
         # copy extension package template to working directory
         if os.path.exists(extension_source_dir):
-            print(f"Removing working directory: {config.source_dir}")
+            print(f"Removing working directory: {extension_source_dir}")
+            # Validate extension_source_dir path to prevent accidental deletion
+            ext_dir_abs = os.path.abspath(extension_source_dir)
+            work_dir_abs = os.path.abspath(config.work_dir)
+            if not ext_dir_abs.startswith(work_dir_abs + os.sep):
+                raise ValueError(f"Extension directory outside work directory: {ext_dir_abs}")
             shutil.rmtree(extension_source_dir)
         check_run(["mkdir", "-p", extension_source_dir], cwd=config.work_dir)
         print(f'Copying : {_source("etc/templates/setup.py")} to {extension_source_dir}')
@@ -647,7 +797,7 @@ def prepare_extensions_release() -> None:
         setup_file = os.path.join(extension_source_dir, "setup.py")
         sed(setup_file, "{{package-name}}", extension)
         sed(setup_file, "{{version}}", config.new_version)
-        sed(setup_file, "{{data - files}}", re.escape("('share/jupyter/labextensions', 'build/labextensions', '**')"))
+        sed(setup_file, "{{data - files}}", "('share/jupyter/labextensions', 'build/labextensions', '**')")
         sed(setup_file, "{{install - requires}}", f"'elyra-server=={config.new_version}',")
         sed(setup_file, "{{description}}", f"'{extensions[extension].description}'")
 
@@ -675,7 +825,12 @@ def prepare_runtime_extensions_package_release() -> None:
         print(f"Preparing package : {package} at {package_source_dir}")
         # copy extension package template to working directory
         if os.path.exists(package_source_dir):
-            print(f"Removing working directory: {config.source_dir}")
+            print(f"Removing working directory: {package_source_dir}")
+            # Validate package_source_dir path to prevent accidental deletion
+            pkg_dir_abs = os.path.abspath(package_source_dir)
+            work_dir_abs = os.path.abspath(config.work_dir)
+            if not pkg_dir_abs.startswith(work_dir_abs + os.sep):
+                raise ValueError(f"Package directory outside work directory: {pkg_dir_abs}")
             shutil.rmtree(package_source_dir)
         check_run(["mkdir", "-p", package_source_dir], cwd=config.work_dir)
         print(f'Copying : {_source("etc/templates/setup.py")} to {package_source_dir}')
@@ -717,7 +872,7 @@ def prepare_changelog() -> None:
     generate_changelog()
     # commit
     check_run(
-        ["git", "commit", "-a", "-m", f"Update changelog for release {config.new_version}"], cwd=config.source_dir
+        ["git", "commit", "-s", "-a", "-m", f"Update changelog for release {config.new_version}"], cwd=config.source_dir
     )
 
 
@@ -731,12 +886,12 @@ def prepare_release() -> None:
 
     # clone repository
     checkout_code()
-    # generate changelog with new release list of commits
-    prepare_changelog()
     # Update to new release version
     update_version_to_release()
+    # build packages to update yarn.lock
+    update_yarn_lock()
     # commit and tag
-    check_run(["git", "commit", "-a", "-m", f"Release v{config.new_version}"], cwd=config.source_dir)
+    check_run(["git", "commit", "-s", "-a", "-m", f"Release v{config.new_version}"], cwd=config.source_dir)
     check_run(["git", "tag", config.tag], cwd=config.source_dir)
     # server-only wheel
     build_server()
@@ -746,8 +901,10 @@ def prepare_release() -> None:
     show_release_artifacts()
     # back to development
     update_version_to_dev()
+    # build packages to update yarn.lock
+    update_yarn_lock()
     # commit
-    check_run(["git", "commit", "-a", "-m", f"Prepare for next development iteration"], cwd=config.source_dir)
+    check_run(["git", "commit", "-s", "-a", "-m", f"Prepare for next development iteration"], cwd=config.source_dir)
     # prepare extensions
     prepare_extensions_release()
     # prepare runtime extsnsions
@@ -763,19 +920,19 @@ def publish_release(working_dir) -> None:
         f"{config.source_dir}/dist/elyra_server-{config.new_version}-py3-none-any.whl",
         f"{config.source_dir}/dist/elyra_server-{config.new_version}.tar.gz",
         f"{config.work_dir}/airflow-notebook/dist/airflow_notebook-{config.new_version}-py3-none-any.whl",
-        f"{config.work_dir}/airflow-notebook/dist/airflow-notebook-{config.new_version}.tar.gz",
+        f"{config.work_dir}/airflow-notebook/dist/airflow_notebook-{config.new_version}.tar.gz",
         f"{config.work_dir}/kfp-notebook/dist/kfp_notebook-{config.new_version}-py3-none-any.whl",
-        f"{config.work_dir}/kfp-notebook/dist/kfp-notebook-{config.new_version}.tar.gz",
+        f"{config.work_dir}/kfp-notebook/dist/kfp_notebook-{config.new_version}.tar.gz",
         f"{config.work_dir}/elyra-code-snippet-extension/dist/elyra_code_snippet_extension-{config.new_version}-py3-none-any.whl",
-        f"{config.work_dir}/elyra-code-snippet-extension/dist/elyra-code-snippet-extension-{config.new_version}.tar.gz",
+        f"{config.work_dir}/elyra-code-snippet-extension/dist/elyra_code_snippet_extension-{config.new_version}.tar.gz",
         f"{config.work_dir}/elyra-pipeline-editor-extension/dist/elyra_pipeline_editor_extension-{config.new_version}-py3-none-any.whl",
-        f"{config.work_dir}/elyra-pipeline-editor-extension/dist/elyra-pipeline-editor-extension-{config.new_version}.tar.gz",
+        f"{config.work_dir}/elyra-pipeline-editor-extension/dist/elyra_pipeline_editor_extension-{config.new_version}.tar.gz",
         f"{config.work_dir}/elyra-python-editor-extension/dist/elyra_python_editor_extension-{config.new_version}-py3-none-any.whl",
-        f"{config.work_dir}/elyra-python-editor-extension/dist/elyra-python-editor-extension-{config.new_version}.tar.gz",
+        f"{config.work_dir}/elyra-python-editor-extension/dist/elyra_python_editor_extension-{config.new_version}.tar.gz",
         f"{config.work_dir}/elyra-r-editor-extension/dist/elyra_r_editor_extension-{config.new_version}-py3-none-any.whl",
-        f"{config.work_dir}/elyra-r-editor-extension/dist/elyra-r-editor-extension-{config.new_version}.tar.gz",
+        f"{config.work_dir}/elyra-r-editor-extension/dist/elyra_r_editor_extension-{config.new_version}.tar.gz",
         f"{config.work_dir}/elyra-scala-editor-extension/dist/elyra_scala_editor_extension-{config.new_version}-py3-none-any.whl",
-        f"{config.work_dir}/elyra-scala-editor-extension/dist/elyra-scala-editor-extension-{config.new_version}.tar.gz",
+        f"{config.work_dir}/elyra-scala-editor-extension/dist/elyra_scala_editor_extension-{config.new_version}.tar.gz",
     ]
 
     print("-----------------------------------------------------------------")
@@ -813,17 +970,17 @@ def publish_release(working_dir) -> None:
     check_run(["git", "checkout", config.tag], cwd=config.source_dir)
     check_run(["git", "status"], cwd=config.source_dir)
 
-    print("-----------------------------------------------------------------")
-    print("-------------------- Pushing npm packages -----------------------")
-    print("-----------------------------------------------------------------")
+    # print("-----------------------------------------------------------------")
+    # print("-------------------- Pushing npm packages -----------------------")
+    # print("-----------------------------------------------------------------")
 
-    # publish npm packages
-    print()
-    print(f"publishing npm packages")
-    check_run(
-        ["lerna", "publish", "--yes", "from-package", "--no-git-tag-version", "--no-verify-access", "--no-push"],
-        cwd=config.source_dir,
-    )
+    # # publish npm packages
+    # print()
+    # print(f"publishing npm packages")
+    # check_run(
+    #     ["lerna", "publish", "--yes", "from-package", "--no-git-tag-version", "--no-verify-access", "--no-push"],
+    #     cwd=config.source_dir,
+    # )
 
     print("-----------------------------------------------------------------")
     print("-------------------- Pushing container images -------------------")

--- a/docs/source/developer_guide/architecture.md
+++ b/docs/source/developer_guide/architecture.md
@@ -1,0 +1,334 @@
+<!--
+{% comment %}
+Copyright 2018-2025 Elyra Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+# Elyra Architecture
+
+This document provides a comprehensive overview of the Elyra software architecture, 
+including its major components, relationships, and key properties.
+
+## Overview
+
+Elyra is a set of AI-centric extensions to JupyterLab that provides enhanced functionality for data science workflows.
+It enables users to create, edit, and run complex machine learning pipelines in distributed runtime environments such as 
+Kubeflow Pipelines and Apache Airflow.
+
+## High-Level Architecture
+
+Elyra follows a modular, extensible architecture built on top of JupyterLab's extension framework. 
+The system is composed of several major subsystems that work together to provide a comprehensive data science platform.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                                  Frontend (Browser)                             │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│  JupyterLab Extensions                                                          │
+│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐ ┌──────────────┐   │
+│  │ Pipeline Editor │ │ Script Editors  │ │ Code Snippets   │ │ Metadata UI  │   │
+│  │                 │ │ (Python/R/Scala)│ │                 │ │              │   │
+│  └─────────────────┘ └─────────────────┘ └─────────────────┘ └──────────────┘   │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                              JupyterLab Core                                    │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                           Backend (Jupyter Server)                              │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│  Elyra Server Extension (ElyraApp)                                              │
+│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐ ┌──────────────┐   │
+│  │ Pipeline        │ │ Metadata        │ │ Component       │ │ Content      │   │
+│  │ Processing      │ │ Management      │ │ Catalog         │ │ Management   │   │
+│  │ Engine          │ │ Service         │ │ Service         │ │ Service      │   │
+│  └─────────────────┘ └─────────────────┘ └─────────────────┘ └──────────────┘   │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                              Jupyter Server                                     │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                             Storage Layer                                       │
+│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐│
+│  │ File System     │ │ Metadata Store  │ │ Component Cache │ │ Pipeline        ││
+│  │ (Notebooks,     │ │ (JSON Files)    │ │ (Local Cache)   │ │ Snapshot        ││
+│  │ Scripts, etc.)  │ │                 │ │                 │ │ (s3/minio)      ││
+│  └─────────────────┘ └─────────────────┘ └─────────────────┘ └─────────────────┘│
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                            External Runtimes                                    │
+│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐                    │
+│  │ Kubeflow        │ │ Apache Airflow  │ │ Local Runtime   │                    │
+│  │ Pipelines       │ │                 │ │                 │                    │
+│  └─────────────────┘ └─────────────────┘ └─────────────────┘                    │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Core Components
+
+### 1. Frontend Components (JupyterLab Extensions)
+
+#### Pipeline Editor Extension
+- **Purpose**: Low code/No code Visual pipeline designer and editor
+- **Key Properties**: 
+  - Low code/No code drag-and-drop interface for pipeline creation
+  - Node-based workflow representation
+  - Supports Jupyter Notebooks, Scripts, and runtime-specific components
+  - Integration with JupyterLab file browser
+- **Relationships**: Communicates and Integrates with Pipeline Processing Engine via REST API
+
+#### Script Editors (Python/R/Scala)
+- **Purpose**: Enhanced script editing with runtime execution capabilities 
+- **Key Properties**:
+  - Syntax highlighting and code completion
+  - Direct script execution on remote runtimes
+  - Integration with kernel management
+- **Relationships**: Extends JupyterLab's editor framework
+
+#### Code Snippets Extension
+- **Purpose**: Reusable code-snippets management
+- **Key Properties**:
+  - Searchable snippet library
+  - Language-agnostic snippet support
+  - Integration with all editor types
+- **Relationships**: Uses Metadata Service for snippet storage
+
+#### Metadata UI Components
+- **Purpose**: User interface for runtime and component configuration
+- **Key Properties**:
+  - Form-based metadata editing
+  - Schema-driven validation
+  - Dynamic form generation based on metadata schema
+- **Relationships**: Directly interfaces with the Metadata Management Service
+
+### 2. Backend Services (Jupyter Server Extension)
+
+#### ElyraApp (Main Application)
+- **Purpose**: Central orchestrator and entry point
+- **Key Properties**:
+  - Extends Jupyter Server Extension framework
+  - Manages component lifecycle
+  - Handles HTTP request routing
+- **Relationships**: Coordinates all backend services and manages their initialization
+
+#### Pipeline Processing Engine
+- **Purpose**: Core pipeline execution and management system
+- **Key Properties**:
+  - Runtime-agnostic pipeline processing
+  - Extensible processor architecture
+  - Pipeline validation and transformation
+- **Relationships**: 
+  - Uses Metadata Service for runtime configurations
+  - Interfaces with external runtime systems
+  - Processes pipeline definitions from Pipeline Editor
+
+**Sub-components:**
+- **PipelineProcessor**: Abstract base for runtime-specific processors
+- **KFPProcessor**: Kubeflow Pipelines implementation
+- **AirflowProcessor**: Apache Airflow implementation
+- **LocalProcessor**: Local execution implementation
+
+#### Metadata Management Service
+- **Purpose**: Schema-driven configuration and metadata storage
+- **Key Properties**:
+  - JSON Schema validation
+  - Pluggable storage backends
+  - Extensible schema system via entry points
+  - REST API for CRUD operations
+- **Relationships**: 
+  - Provides configuration data to all other services
+  - Uses Storage Layer for persistence
+  - Supports dynamic schema registration
+
+**Sub-components:**
+- **MetadataManager**: Core metadata operations
+- **SchemaManager**: Schema validation and management
+- **Schemaspace**: Logical grouping of related schemas
+- **SchemasProvider**: Dynamic schema provisioning
+
+#### Component Catalog Service
+- **Purpose**: Pipeline component discovery and management
+- **Key Properties**:
+  - Component registry and caching
+  - Multiple catalog connector support
+  - Automatic component discovery
+  - Component metadata enrichment
+- **Relationships**: 
+  - Integrates with external component repositories
+  - Provides components to Pipeline Editor
+  - Uses caching for performance optimization
+
+#### Content Management Service
+- **Purpose**: Enhanced file and content handling
+- **Key Properties**:
+  - Content parsing and metadata extraction
+  - File property analysis
+  - Integration with Jupyter's content management
+- **Relationships**: Extends Jupyter Server's content management
+
+### 3. Storage Layer
+
+#### File System Storage
+- **Purpose**: Primary storage for notebooks, scripts, and user files
+- **Key Properties**:
+  - Standard file system operations
+  - Integration with Jupyter's file management
+  - Support for various file formats
+
+#### Metadata Store
+- **Purpose**: Persistent storage for configuration and metadata
+- **Key Properties**:
+  - Default implementation uses JSON files
+  - Pluggable storage architecture
+  - Schema-based organization
+- **Default Location**: `{JUPYTER_DATA_DIR}/metadata/`
+
+#### Component Cache
+- **Purpose**: Local caching of pipeline components
+- **Key Properties**:
+  - Performance optimization for component loading
+  - Automatic cache invalidation
+  - Background cache updates
+
+### 4. External Runtime Integration
+
+#### Kubeflow Pipelines (KFP)
+- **Integration Method**: REST API and Python SDK
+- **Key Capabilities**:
+  - Pipeline compilation and submission
+  - Experiment and run management
+  - Artifact tracking and visualization
+
+#### Apache Airflow
+- **Integration Method**: DAG generation and submission
+- **Key Capabilities**:
+  - Workflow scheduling and monitoring
+  - Task dependency management
+  - Operator-based execution model
+
+#### Local Runtime
+- **Integration Method**: Direct process execution
+- **Key Capabilities**:
+  - Local development and testing
+  - Simplified execution model
+  - No external dependencies
+
+## Key Architectural Patterns
+
+### 1. Extension-Based Architecture
+Elyra leverages JupyterLab's extension system to provide modular functionality. Each major feature is implemented as a separate extension that can be independently developed, tested, and deployed.
+
+### 2. Service-Oriented Design
+Backend services are designed as independent modules with well-defined interfaces, enabling loose coupling and high cohesion.
+
+### 3. Schema-Driven Configuration
+The metadata system uses JSON Schema to drive configuration management, ensuring consistency and enabling dynamic UI generation.
+
+### 4. Plugin Architecture
+Both pipeline processors and component catalog connectors use a plugin pattern, allowing for easy extension with new runtime support.
+
+### 5. Event-Driven Communication
+Components communicate through well-defined APIs and event mechanisms, reducing direct dependencies.
+
+## Security Architecture
+
+### Authentication and Authorization
+- Inherits security model from Jupyter Server
+- No additional authentication mechanisms
+- Relies on Jupyter's token-based authentication
+
+### Data Security
+- All sensitive configuration data (passwords, tokens) is stored in metadata
+- No plaintext storage of credentials in pipeline definitions
+- Runtime-specific security handled by target platforms
+
+### Network Security
+- All external communications use HTTPS where supported
+- Runtime credentials managed through secure metadata storage
+- No direct network exposure beyond Jupyter Server
+
+## Scalability and Performance
+
+### Horizontal Scalability
+- Pipeline execution scales through external runtime systems
+- Component catalog supports distributed repositories
+- The metadata service can be configured with alternative storage backends
+
+### Performance Optimizations
+- Component caching reduces repeated network requests
+- Lazy loading of pipeline components
+- Efficient pipeline validation and compilation
+
+### Resource Management
+- Memory usage optimized through component caching strategies
+- Background processes for cache management and updates
+- Configurable resource limits through Jupyter Server
+
+## Extension Points
+
+### 1. Runtime Processors
+New runtime systems can be integrated by implementing the `RuntimePipelineProcessor` interface and registering through entry points.
+
+### 2. Component Catalog Connectors
+Custom component repositories can be integrated through the `ComponentCatalogConnector` interface.
+
+### 3. Metadata Schemas
+New configuration schemas can be added through the `SchemasProvider` mechanism.
+
+### 4. Storage Backends
+Alternative storage implementations can be provided through the `MetadataStore` interface.
+
+## Data Flow
+
+### Pipeline Creation and Execution
+1. User creates pipeline in Pipeline Editor (Frontend)
+2. Pipeline definition sent to Pipeline Processing Engine (Backend)
+3. Engine validates pipeline against schemas
+4. Runtime-specific processor transforms pipeline
+5. Pipeline submitted to the external runtime system
+6. Results and status tracked through runtime APIs
+
+### Component Discovery
+1. Component Catalog Service queries registered connectors
+2. Components cached locally for performance
+3. Component metadata exposed through REST API
+4. Pipeline Editor requests available components
+5. User adds components to the pipeline canvas
+
+### Metadata Management
+1. User configures runtimes through the Metadata UI
+2. Configuration validated against JSON schemas
+3. Metadata persisted through the storage layer
+4. Other services query metadata as needed
+5. Changes propagated through cache invalidation
+
+## Quality Attributes
+
+### Maintainability
+- Modular architecture with clear separation of concerns
+- Comprehensive test coverage across components
+- Standardized coding patterns and conventions
+
+### Extensibility
+- Plugin architecture for runtimes and components
+- Schema-driven configuration system
+- Entry point-based service discovery
+
+### Reliability
+- Comprehensive error handling and logging
+- Graceful degradation when external services are unavailable
+- Robust pipeline validation before execution
+
+### Usability
+- Intuitive visual pipeline editor
+- Consistent UI patterns across extensions
+- Comprehensive documentation and examples
+
+This architecture enables Elyra to provide a comprehensive, extensible platform for AI and data science workflows while 
+maintaining integration with the broader Jupyter ecosystem.

--- a/docs/source/getting_started/changelog.md
+++ b/docs/source/getting_started/changelog.md
@@ -2,6 +2,20 @@
 
 A summary of new feature highlights is located on the [GitHub release page](https://github.com/elyra-ai/elyra/releases).
 
+## Release 4.0.0 - 08/15/2025
+
+Our 4.0.0 release includes the following high-level changes
+
+- Add support for JupyterLab 4.x - [#3201](https://github.com/elyra-ai/elyra/pull/3201)
+- Update JupyterLab version compatibility all way to 4.3.x  - [#3293](https://github.com/elyra-ai/elyra/pull/3293)
+- Switch from elyra-code-viewer to jupyterlab-code-viewer - [#3265](https://github.com/elyra-ai/elyra/pull/3265)
+- Update jupyterlab-git to 0.51.2 to fix vulnerability - [#3319](https://github.com/elyra-ai/elyra/pull/3319)
+- Enable conditional install of runtime and it's dependencies (e.g: KFP, Airflow) - [#3248](https://github.com/elyra-ai/elyra/pull/3248)
+- Add Airflow 2.x support for generic pipelines and generic components - [#3167](https://github.com/elyra-ai/elyra/pull/3167)
+- Add support to Python 3.12 and 3.13 - [#3311](https://github.com/elyra-ai/elyra/pull/3311)
+- Remove Python 3.8 support as it reached EOL - [#3277](https://github.com/elyra-ai/elyra/pull/3277)
+- Multiple dependency updates with security fixes
+
 ## Release 4.0.0rc5 - 07/24/2025
 
 - Update jupyterlab-git to 0.51.2 to fix vulnerability - [#3319](https://github.com/elyra-ai/elyra/pull/3319)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,7 +67,7 @@ Elyra is a set of AI-centric extensions to JupyterLab Notebooks.
    recipes/creating-a-custom-runtime-image.md
    recipes/visualizing-output-in-the-kfp-ui.md
    recipes/configure-airflow-as-a-runtime.md
-   
+
 .. toctree::
    :maxdepth: 1
    :caption: Developer Guide
@@ -76,6 +76,7 @@ Elyra is a set of AI-centric extensions to JupyterLab Notebooks.
    developer_guide/development-workflow.md
    developer_guide/issue-management.md
    developer_guide/logging.md
+   developer_guide/architecture.md
    developer_guide/metadata.md
    developer_guide/pipelines.md
    developer_guide/pipeline-component-connectors.md

--- a/docs/source/user_guide/env-variables-file-based-nodes.md
+++ b/docs/source/user_guide/env-variables-file-based-nodes.md
@@ -63,3 +63,16 @@ set env var **`ELYRA_GENERIC_NODES_ENABLE_SCRIPT_OUTPUT_TO_S3`** to **`false`**.
 If you want to set `ELYRA_GENERIC_NODES_ENABLE_SCRIPT_OUTPUT_TO_S3` to `false`, you can do so in either
 - Pipeline Editor at Pipeline Properties - Generic Node Defaults - Environment Variables or at Node Properties - Additional Properties - Environment Variables
 - Statically baked into Jupyterlab container definition for use in KFP or Airflow runtime image container build
+
+### `ELYRA_INSTALL_PACKAGES`
+
+Scope: Runtime image task (Airflow) or component (KFP) execution of file-based node Jupyter notebooks, Python scripts, and R scripts (bootstrapper pipeline run)
+
+Impact: Controls whether Elyra’s required packages are installed automatically during the bootstrap phase.
+
+Default: `true` if not specified, i.e. no explicit setting of this environment variable necessary.
+
+Background: 
+In air-gapped environments (where internet access is restricted), Elyra cannot automatically download its dependencies. Additionally, in some cases, the required packages may already be installed on the system.
+
+If your environment already has Elyra’s dependencies available, you can set **`ELYRA_INSTALL_PACKAGES`** to **`false`** to avoid installing them again or to avoid having errors in air-gapped environments.

--- a/elyra/airflow/bootstrapper.py
+++ b/elyra/airflow/bootstrapper.py
@@ -45,6 +45,11 @@ enable_pipeline_info = os.getenv("ELYRA_ENABLE_PIPELINE_INFO", "true").lower() =
 enable_generic_node_script_output_to_s3 = (
     os.getenv("ELYRA_GENERIC_NODES_ENABLE_SCRIPT_OUTPUT_TO_S3", "true").lower() == "true"
 )
+# Set it to false to disable automatic package installation.
+# This is useful in airgapped environments where the image
+# already contains the required packages.
+install_packages = os.getenv("ELYRA_INSTALL_PACKAGES", "true").lower() == "true"
+
 pipeline_name = None  # global used in formatted logging
 operation_name = None  # global used in formatted logging
 
@@ -584,10 +589,9 @@ def main():
     input_params = OpUtil.parse_arguments(sys.argv[1:])
     OpUtil.log_operation_info("starting operation")
     t0 = time.time()
-    # must be commented out in airgapped images if packages from
-    # https://github.com/elyra-ai/elyra/blob/main/etc/generic/requirements-elyra.txt
-    # already installed via central pip env during container build
-    OpUtil.package_install()
+
+    if install_packages:
+        OpUtil.package_install()
 
     # Create the appropriate instance, process dependencies and execute the operation
     file_op = FileOpBase.get_instance(**input_params)

--- a/elyra/kfp/bootstrapper.py
+++ b/elyra/kfp/bootstrapper.py
@@ -51,6 +51,11 @@ enable_pipeline_info = os.getenv("ELYRA_ENABLE_PIPELINE_INFO", "true").lower() =
 enable_generic_node_script_output_to_s3 = (
     os.getenv("ELYRA_GENERIC_NODES_ENABLE_SCRIPT_OUTPUT_TO_S3", "true").lower() == "true"
 )
+# Set it to false to disable automatic package installation.
+# This is useful in airgapped environments where the image
+# already contains the required packages.
+install_packages = os.getenv("ELYRA_INSTALL_PACKAGES", "true").lower() == "true"
+
 pipeline_name = None  # global used in formatted logging
 operation_name = None  # global used in formatted logging
 
@@ -768,10 +773,9 @@ def main():
     input_params = OpUtil.parse_arguments(sys.argv[1:])
     OpUtil.log_operation_info("starting operation")
     t0 = time.time()
-    # must be commented out in airgapped images if packages from
-    # https://github.com/elyra-ai/elyra/blob/main/etc/generic/requirements-elyra.txt
-    # already installed via central pip env during container build
-    OpUtil.package_install(user_volume_path=input_params.get("user-volume-path"))
+
+    if install_packages:
+        OpUtil.package_install(user_volume_path=input_params.get("user-volume-path"))
 
     # Create the appropriate instance, process dependencies and execute the operation
     file_op = FileOpBase.get_instance(**input_params)

--- a/etc/generic/requirements-elyra.txt
+++ b/etc/generic/requirements-elyra.txt
@@ -16,7 +16,7 @@ prompt-toolkit==3.0.43
 requests==2.32.4
 tornado==6.5.1
 traitlets==5.10.0
-urllib3==1.26.19
+urllib3==2.5.0
 #
 # These excluded are transitive dependencies of the included python packages.
 #ansiwrap==0.8.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,8 +196,6 @@ ignore-vcs = true
 [tool.hatch.build.targets.sdist]
 artifacts = [
     "labextensions/elyra_code_snippet_extension/labextension",
-    # This extension is not part of ODH distribution
-    # "labextensions/elyra_code_viewer_extension/labextension",
     "labextensions/elyra_metadata_common/labextension",
     "labextensions/elyra_metadata_extension/labextension",
     "labextensions/elyra_pipeline_editor_extension/labextension",


### PR DESCRIPTION
Cherry-picking improvements from Upstream:

Making package installation optional  https://github.com/elyra-ai/elyra/pull/3328
Bump urllib3 from 1.26.19 to 2.5.0 in /etc/generic  https://github.com/elyra-ai/elyra/pull/3323
Make Jupyterlab pin more flexible to new releases https://github.com/elyra-ai/elyra/pull/3320

And documentation improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added an environment variable to disable automatic package installation for air‑gapped deployments.
* Documentation
  * Added an architecture overview to the developer guide.
  * Documented the new environment variable and updated docs navigation.
  * Added a new Release 4.0.0 changelog section.
* Chores
  * Relaxed JupyterLab version constraint to allow compatible newer releases.
  * Upgraded core HTTP dependency.
  * Removed a deprecated lab extension from distribution.
  * Improved build cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->