### PR TITLE
RHOAIENG-35198: Rename AI Pipelines to Pipelines

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -22,6 +22,12 @@ import 'cypress-real-events/support';
 
 import '../utils/snapshots/add-commands';
 
+Cypress.Commands.add('installPythonKernel', (): void => {
+  cy.exec('python -m ipykernel install --user --name python3 --display-name "Python 3 (ipykernel)"', {
+    failOnNonZeroExit: false
+  });
+});
+
 Cypress.Commands.add('installRuntimeConfig', ({ type } = {}): void => {
   const kfpRuntimeInstallCommand =
     'elyra-metadata create runtimes \
@@ -68,7 +74,7 @@ Cypress.Commands.add('createRuntimeConfig', ({ type } = {}): void => {
   cy.findByLabelText(/^display name/i).type(`${type} Test Runtime`);
 
   if (type === 'kfp') {
-    cy.findByLabelText(/ai .* endpoint\*/i).type(
+    cy.findByLabelText(/api endpoint\*/i).type(
       'https://kubernetes-service.ibm.com/pipeline'
     );
   } else {
@@ -147,17 +153,17 @@ Cypress.Commands.add(
       switch (type) {
         case 'kfp':
           cy.get(
-            '.jp-LauncherCard[data-category="Elyra"][title="Pipeline Editor"]'
+            '.jp-LauncherCard[data-category="Elyra"][title*="Pipeline Editor"]'
           ).click();
           break;
         case 'airflow':
           cy.get(
-            '.jp-LauncherCard[data-category="Elyra"][title="Apache Airflow Pipeline Editor"]'
+            '.jp-LauncherCard[data-category="Elyra"][title*="Pipeline Editor"]'
           ).click();
           break;
         default:
           cy.get(
-            '.jp-LauncherCard[data-category="Elyra"][title="Generic Pipeline Editor"]'
+            '.jp-LauncherCard[data-category="Elyra"][title*="Pipeline Editor"]'
           ).click();
           break;
       }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -22,12 +22,6 @@ import 'cypress-real-events/support';
 
 import '../utils/snapshots/add-commands';
 
-Cypress.Commands.add('installPythonKernel', (): void => {
-  cy.exec('python -m ipykernel install --user --name python3 --display-name "Python 3 (ipykernel)"', {
-    failOnNonZeroExit: false
-  });
-});
-
 Cypress.Commands.add('installRuntimeConfig', ({ type } = {}): void => {
   const kfpRuntimeInstallCommand =
     'elyra-metadata create runtimes \
@@ -153,17 +147,17 @@ Cypress.Commands.add(
       switch (type) {
         case 'kfp':
           cy.get(
-            '.jp-LauncherCard[data-category="Elyra"][title*="Pipeline Editor"]'
+            '.jp-LauncherCard[data-category="Elyra"][title="Pipeline Editor"]'
           ).click();
           break;
         case 'airflow':
           cy.get(
-            '.jp-LauncherCard[data-category="Elyra"][title*="Pipeline Editor"]'
+            '.jp-LauncherCard[data-category="Elyra"][title="Apache Airflow Pipeline Editor"]'
           ).click();
           break;
         default:
           cy.get(
-            '.jp-LauncherCard[data-category="Elyra"][title*="Pipeline Editor"]'
+            '.jp-LauncherCard[data-category="Elyra"][title="Generic Pipeline Editor"]'
           ).click();
           break;
       }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -147,7 +147,7 @@ Cypress.Commands.add(
       switch (type) {
         case 'kfp':
           cy.get(
-            '.jp-LauncherCard[data-category="Elyra"][title="AI Pipeline Editor"]'
+            '.jp-LauncherCard[data-category="Elyra"][title="Pipeline Editor"]'
           ).click();
           break;
         case 'airflow':

--- a/cypress/tests/launcher.cy.ts
+++ b/cypress/tests/launcher.cy.ts
@@ -37,7 +37,7 @@ describe('Elyra launcher is in use', () => {
     //   '.jp-LauncherCard[data-category="Elyra"][title="Apache Airflow Pipeline Editor"]:visible'
     // );
     cy.get(
-      '.jp-LauncherCard[data-category="Elyra"][title="Pipeline Editor"]:visible'
+      '.jp-LauncherCard[data-category="Elyra"][title*="Pipeline Editor"]:visible'
     );
     // Script editor extension is available
     cy.get(

--- a/cypress/tests/launcher.cy.ts
+++ b/cypress/tests/launcher.cy.ts
@@ -37,7 +37,7 @@ describe('Elyra launcher is in use', () => {
     //   '.jp-LauncherCard[data-category="Elyra"][title="Apache Airflow Pipeline Editor"]:visible'
     // );
     cy.get(
-      '.jp-LauncherCard[data-category="Elyra"][title*="Pipeline Editor"]:visible'
+      '.jp-LauncherCard[data-category="Elyra"][title="Pipeline Editor"]:visible'
     );
     // Script editor extension is available
     cy.get(

--- a/cypress/tests/launcher.cy.ts
+++ b/cypress/tests/launcher.cy.ts
@@ -37,7 +37,7 @@ describe('Elyra launcher is in use', () => {
     //   '.jp-LauncherCard[data-category="Elyra"][title="Apache Airflow Pipeline Editor"]:visible'
     // );
     cy.get(
-      '.jp-LauncherCard[data-category="Elyra"][title="AI Pipeline Editor"]:visible'
+      '.jp-LauncherCard[data-category="Elyra"][title="Pipeline Editor"]:visible'
     );
     // Script editor extension is available
     cy.get(

--- a/cypress/tests/pipeline.cy.ts
+++ b/cypress/tests/pipeline.cy.ts
@@ -895,7 +895,7 @@ describe('Pipeline Editor tests', () => {
 
   it('kfp pipeline toolbar should display expected runtime', () => {
     cy.createPipeline({ type: 'kfp' });
-    cy.get('.toolbar-icon-label').contains(/runtime: ai pipelines/i);
+    cy.get('.toolbar-icon-label').contains(/runtime: pipelines/i);
   });
 
   it.skip('airflow pipeline toolbar should display expected runtime (Airflow is not part of ODH distribution)', () => {

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://raw.githubusercontent.com/elyra-ai/elyra/main/elyra/metadata/schemas/meta-schema.json",
   "$id": "https://raw.githubusercontent.com/elyra-ai/elyra/main/elyra/metadata/schemas/kfp.json",
-  "title": "AI Pipelines",
+  "title": "Pipelines",
   "name": "kfp",
   "schemaspace": "runtimes",
   "schemaspace_id": "130b8e00-de7c-4b32-b553-b4a52824a3b5",
   "metadata_class_name": "elyra.pipeline.kfp.kfp_metadata.KfpMetadata",
   "runtime_type": "KUBEFLOW_PIPELINES",
   "uihints": {
-    "title": "AI Pipelines runtimes",
+    "title": "Pipelines runtimes",
     "icon": "elyra:runtimes",
     "reference_url": "https://elyra.readthedocs.io/en/latest/user_guide/runtime-conf.html"
   },
@@ -21,7 +21,7 @@
     },
     "display_name": {
       "title": "Display Name",
-      "description": "Display name of this AI Pipelines configuration",
+      "description": "Display name of this pipelines configuration",
       "type": "string",
       "minLength": 1
     },
@@ -40,47 +40,47 @@
         },
         "description": {
           "title": "Description",
-          "description": "Description of this AI Pipelines configuration",
+          "description": "Description of this pipelines configuration",
           "type": "string"
         },
         "api_endpoint": {
-          "title": "AI Pipelines API Endpoint",
-          "description": "The AI Pipelines API endpoint",
+          "title": "API Endpoint",
+          "description": "The pipelines API endpoint",
           "type": "string",
           "format": "uri",
           "uihints": {
-            "category": "AI Pipelines",
-            "ui:placeholder": "https://your-ai-pipeline-service:port"
+            "category": "Pipelines",
+            "ui:placeholder": "https://your-pipeline-service:port"
           }
         },
         "public_api_endpoint": {
-          "title": "Public AI Pipelines API Endpoint",
-          "description": "The public AI Pipelines API endpoint",
+          "title": "Public API endpoint",
+          "description": "The public pipelines API endpoint",
           "type": "string",
           "format": "uri",
           "uihints": {
-            "category": "AI Pipelines",
-            "ui:placeholder": "https://your-ai-pipeline-service:port"
+            "category": "Pipelines",
+            "ui:placeholder": "https://your-pipeline-service:port"
           }
         },
         "user_namespace": {
-          "title": "AI Pipelines User Namespace",
-          "description": "The AI Pipelines user namespace used to create experiments",
+          "title": "User namespace",
+          "description": "The pipelines user namespace used to create experiments",
           "type": "string",
           "pattern": "^[a-z0-9][-a-z0-9]*[a-z0-9]$",
           "maxLength": 63,
           "uihints": {
-            "category": "AI Pipelines"
+            "category": "Pipelines"
           }
         },
         "engine": {
-          "title": "AI Pipelines engine",
-          "description": "The AI Pipelines engine in use",
+          "title": "Engine",
+          "description": "The pipelines engine in use",
           "type": "string",
           "enum": ["Argo"],
           "default": "Argo",
           "uihints": {
-            "category": "AI Pipelines"
+            "category": "Pipelines"
           }
         },
         "auth_type": {
@@ -90,24 +90,24 @@
           "enum": ["{AUTH_PROVIDER_PLACEHOLDERS}"],
           "default": "{DEFAULT_AUTH_PROVIDER_PLACEHOLDER}",
           "uihints": {
-            "category": "AI Pipelines"
+            "category": "Pipelines"
           }
         },
         "api_username": {
-          "title": "AI Pipelines API Endpoint Username",
-          "description": "The AI Pipelines API endpoint username. This property is required for all authentication types, except NO_AUTHENTICATION and KUBERNETES_SERVICE_ACCOUNT_TOKEN.",
+          "title": "API endpoint username",
+          "description": "The pipelines API endpoint username. This property is required for all authentication types, except NO_AUTHENTICATION and KUBERNETES_SERVICE_ACCOUNT_TOKEN.",
           "type": "string",
           "uihints": {
-            "category": "AI Pipelines"
+            "category": "Pipelines"
           }
         },
         "api_password": {
-          "title": "AI Pipelines API Endpoint Password Or Token",
+          "title": "API endpoint password or token",
           "description": "Password or token to be used for authentication. This property is required for all authentication types, except NO_AUTHENTICATION and KUBERNETES_SERVICE_ACCOUNT_TOKEN.",
           "type": "string",
           "uihints": {
             "ui:field": "@elyra/metadata-extension:plugin.password",
-            "category": "AI Pipelines"
+            "category": "Pipelines"
           }
         },
         "cos_endpoint": {
@@ -184,7 +184,7 @@
         },
         "tags": {
           "title": "Tags",
-          "description": "Tags for categorizing AI Pipelines",
+          "description": "Tags for categorizing pipelines",
           "uniqueItems": true,
           "type": "array",
           "items": {

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -20,7 +20,7 @@
       "const": "kfp"
     },
     "display_name": {
-      "title": "Display Name",
+      "title": "Display name",
       "description": "Display name of this pipelines configuration",
       "type": "string",
       "minLength": 1
@@ -44,7 +44,7 @@
           "type": "string"
         },
         "api_endpoint": {
-          "title": "API Endpoint",
+          "title": "API endpoint",
           "description": "The pipelines API endpoint",
           "type": "string",
           "format": "uri",

--- a/elyra/pipeline/runtime_type.py
+++ b/elyra/pipeline/runtime_type.py
@@ -33,7 +33,7 @@ class RuntimeProcessorType(Enum):
     """
 
     LOCAL = "Local"
-    KUBEFLOW_PIPELINES = "Data Science"
+    KUBEFLOW_PIPELINES = "Pipelines"
     APACHE_AIRFLOW = "Apache Airflow"
     ARGO = "Argo"
     ######################################

--- a/elyra/pipeline/runtime_type.py
+++ b/elyra/pipeline/runtime_type.py
@@ -33,7 +33,7 @@ class RuntimeProcessorType(Enum):
     """
 
     LOCAL = "Local"
-    KUBEFLOW_PIPELINES = "AI"
+    KUBEFLOW_PIPELINES = "Data Science"
     APACHE_AIRFLOW = "Apache Airflow"
     ARGO = "Argo"
     ######################################

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_with_supernode.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_with_supernode.json
@@ -105,7 +105,7 @@
           "type": "execution_node",
           "op": "execute-notebook-node",
           "app_data": {
-            "label": "ai_aws",
+            "label": "aws",
             "component_parameters": {
               "filename": "demo-pipelines/data_science_aws.ipynb",
               "runtime_image": "elyra/tensorflow:1.15.2-py3",
@@ -113,7 +113,7 @@
               "include_subdirectories": false
             },
             "ui_data": {
-              "label": "ai_aws",
+              "label": "aws",
               "image": "useDefaultIcon",
               "x_pos": 814.85107421875,
               "y_pos": 104.74483108520508,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "lodash": "^4.17.21",
     "nyc": "^17.1.0",
     "nyc-config-tsx": "^0.1.0",
-    "prettier": "^3.1.1",
+    "prettier": "^3.6.2",
     "start-server-and-test": "^2.0.3",
     "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",

--- a/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
+++ b/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
@@ -76,7 +76,7 @@ class ComponentCatalogsDisplay extends MetadataDisplay<IMetadataDisplayProps> {
     return (
       <div>
         <h6>Runtime Type</h6>
-        {'AI_PIPELINES'}
+        {'PIPELINES'}
         <br />
         <br />
         <h6>Description</h6>

--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -259,10 +259,10 @@ const extension: JupyterFrontEndPlugin<void> = {
               return `${contextMenuPrefix}Generic ${PIPELINE_EDITOR}`;
             }
             if (commandArgs.isMenu) {
-              return `${commandArgs.runtimeType?.display_name} ${PIPELINE_EDITOR}`;
+              return PIPELINE_EDITOR;
             }
             if (commandArgs.isContextMenu) {
-              return `New ${commandArgs.runtimeType?.display_name} ${PIPELINE_EDITOR}`;
+              return `New ${PIPELINE_EDITOR}`;
             }
             return PIPELINE_EDITOR;
           },
@@ -271,7 +271,7 @@ const extension: JupyterFrontEndPlugin<void> = {
             if (commandArgs.runtimeType?.id === 'LOCAL') {
               return `Generic ${PIPELINE_EDITOR}`;
             }
-            return `${commandArgs.runtimeType?.display_name} ${PIPELINE_EDITOR}`;
+            return PIPELINE_EDITOR;
           },
           iconLabel: (args) => {
             const commandArgs = args as ICommandArgs;
@@ -281,7 +281,7 @@ const extension: JupyterFrontEndPlugin<void> = {
             if (commandArgs.runtimeType?.id === 'LOCAL') {
               return `Generic ${PIPELINE_EDITOR}`;
             }
-            return `${commandArgs.runtimeType?.display_name} ${PIPELINE_EDITOR}`;
+            return PIPELINE_EDITOR;
           },
           icon: (args) => {
             const commandArgs = args as ICommandArgs;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8785,7 +8785,7 @@ __metadata:
     lodash: ^4.17.21
     nyc: ^17.1.0
     nyc-config-tsx: ^0.1.0
-    prettier: ^3.1.1
+    prettier: ^3.6.2
     start-server-and-test: ^2.0.3
     ts-jest: ^29.3.2
     ts-node: ^10.9.2
@@ -14789,12 +14789,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.1.1":
-  version: 3.3.3
-  resolution: "prettier@npm:3.3.3"
+"prettier@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "prettier@npm:3.6.2"
   bin:
     prettier: bin/prettier.cjs
-  checksum: bc8604354805acfdde6106852d14b045bb20827ad76a5ffc2455b71a8257f94de93f17f14e463fe844808d2ccc87248364a5691488a3304f1031326e62d9276e
+  checksum: 0206f5f437892e8858f298af8850bf9d0ef1c22e21107a213ba56bfb9c2387a2020bfda244a20161d8e3dad40c6b04101609a55d370dece53d0a31893b64f861
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is a follow-up to #132, as the new requirement is simply "Pipelines" instead of "AI Pipelines"

I tested this on RHOAI in my rosa cluster, using the container image produced by Elyra CI. There are still a couple instances of "Data Science Pipelines" on the UI, but these must be changed separately, in the notebook controller.

Reviewers and QE, please double check that this is not changing the backend in an unexpected way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Renamed “AI Pipelines” to “Pipelines” across the UI (launcher cards, runtime labels, editor commands, component catalogs).
  - Updated field labels, descriptions, hints and placeholders (API Endpoint, Public API Endpoint, auth fields, tags).

- Bug Fixes
  - Fixed sample pipeline node labels to match the new naming.

- Tests
  - Updated end-to-end tests to reflect the new labels.

- Chores
  - Upgraded code formatting tooling dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->