### PR TITLE
RHOAIENG-31924: Change invalidNodeLabel from Warning to Error

### DIFF
--- a/elyra/pipeline/validation.py
+++ b/elyra/pipeline/validation.py
@@ -820,7 +820,7 @@ class PipelineValidationManager(SingletonConfigurable):
 
         if len(node_label) > label_name_max_length:
             response.add_message(
-                severity=ValidationSeverity.Warning,
+                severity=ValidationSeverity.Error,
                 message_type="invalidNodeLabel",
                 message="Property value exceeds the max length allowed "
                 "({label_name_max_length}). This value may be truncated "
@@ -829,7 +829,7 @@ class PipelineValidationManager(SingletonConfigurable):
             )
         if not matched or matched.group(0) != node_label:
             response.add_message(
-                severity=ValidationSeverity.Warning,
+                severity=ValidationSeverity.Error,
                 message_type="invalidNodeLabel",
                 message="The node label contains characters that may be replaced "
                 "by the runtime service. Node labels should "

--- a/elyra/pipeline/validation.py
+++ b/elyra/pipeline/validation.py
@@ -810,6 +810,11 @@ class PipelineValidationManager(SingletonConfigurable):
     def _validate_label(self, node_id: str, node_label: str, response: ValidationResponse) -> None:
         """
         KFP specific check for the label name when constructing the node operation using dsl
+
+        Note: This validation is primarily for Kubeflow Pipelines (KFP) where labels must conform
+        to Kubernetes naming conventions (max 63 chars, lowercase alphanumeric with dashes/dots/underscores).
+        However, it is currently called for all runtimes.
+
         :param node_id: the unique ID of the node
         :param node_label: the given node name or user customized name/label of the node
         :param response: ValidationResponse containing the issue list to be updated

--- a/elyra/tests/pipeline/test_validation.py
+++ b/elyra/tests/pipeline/test_validation.py
@@ -999,7 +999,7 @@ def test_invalid_node_property_label_max_length(validation_manager):
     validation_manager._validate_label(node_id=node["id"], node_label=invalid_label_name, response=response)
     issues = response.to_json().get("issues")
     assert len(issues) == 1
-    assert issues[0]["severity"] == 2
+    assert issues[0]["severity"] == 1
     assert issues[0]["type"] == "invalidNodeLabel"
     assert issues[0]["data"]["propertyName"] == "label"
     assert issues[0]["data"]["nodeID"] == "test-id"
@@ -1021,7 +1021,7 @@ def test_invalid_node_property_label_bad_characters(validation_manager):
     validation_manager._validate_label(node_id=node["id"], node_label=invalid_label_name, response=response)
     issues = response.to_json().get("issues")
     assert len(issues) == 1
-    assert issues[0]["severity"] == 2
+    assert issues[0]["severity"] == 1
     assert issues[0]["type"] == "invalidNodeLabel"
     assert issues[0]["data"]["propertyName"] == "label"
     assert issues[0]["data"]["nodeID"] == "test-id"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-31924

Before when running Pipeline with Invalid Node Label went unnoticed and could cause a confusion for a user - the changes ensure that Invalid Node Label appears as an error now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now treats invalid node labels as errors rather than warnings.
  * Labels that exceed maximum length or contain disallowed characters will cause validation to fail, blocking submission with clear error messages naming the offending label and node.
* **Tests**
  * Tests updated to expect the stricter error severity for invalid node-label cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->