### PR TITLE
Update urllib3 version to >=2.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,10 @@ dependencies = [
     "tornado>=6.1.0",
     "traitlets>=4.3.2",
     "typing-extensions>=3.10,<5",  # Cap from kfp
-    "urllib3>=1.26.5",
+    "urllib3>=2.6.0",
     "watchdog>=2.1.3",
     "websocket-client",
     "yaspin",
-    # see: https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli
-    "appengine-python-standard",
     "kfp>=2.0.0", # Cap kfp for protobuff compatibility
     "kfp-kubernetes>=1.0.0",
     "pygithub",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,5 +8,6 @@ pytest-console-scripts
 pytest_jupyter
 pytest-tornasync
 pytest_virtualenv
+mock
 requests-mock
 requests-unixsocket


### PR DESCRIPTION
The dependency `appengine-python-standard` could be removed because the issue that required it was [fixed](https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli) a long time ago (`kfp-2.0.0-b16`). As I remove it, I also update urllib3 to >=2.6.0 which has multiple fixed.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Updated HTTP client library minimum to 2.6.0+, improving compatibility and security.
* Removed an unused application server dependency to simplify the project.

## Tests
* Added the mock testing utility to test requirements to support unit testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->