### PR TITLE
RHOAIENG-67031: Updating dependencies to avoid conflicts on notebooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ elyra-image-env: ## Creates a conda env consisting of the dependencies used in i
 	@conda env list | grep -q "$(ELYRA_IMAGE_ENV)" && \
 		conda env remove -y -n $(ELYRA_IMAGE_ENV) || \
 		echo "Environment $(ELYRA_IMAGE_ENV) does not exist, skipping removal"
-	conda create -y -n $(ELYRA_IMAGE_ENV) python=$(PYTHON_VERSION) --channel conda-forge
+	conda create -y -n $(ELYRA_IMAGE_ENV) python=$(PYTHON_VERSION) pip --channel conda-forge
 	$(CONDA_ACTIVATE) $(ELYRA_IMAGE_ENV) && \
 	$(PYTHON_PIP) install -r etc/generic/requirements-elyra.txt && \
 	conda deactivate;

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ elyra-image-env: ## Creates a conda env consisting of the dependencies used in i
 	@conda env list | grep -q "$(ELYRA_IMAGE_ENV)" && \
 		conda env remove -y -n $(ELYRA_IMAGE_ENV) || \
 		echo "Environment $(ELYRA_IMAGE_ENV) does not exist, skipping removal"
-	conda create -y -n $(ELYRA_IMAGE_ENV) python=$(PYTHON_VERSION) pip --channel conda-forge
+	conda create -y -n "$(ELYRA_IMAGE_ENV)" "python=$(PYTHON_VERSION)" pip --channel conda-forge
 	$(CONDA_ACTIVATE) $(ELYRA_IMAGE_ENV) && \
 	$(PYTHON_PIP) install -r etc/generic/requirements-elyra.txt && \
 	conda deactivate;

--- a/elyra/tests/cli/test_pipeline_app.py
+++ b/elyra/tests/cli/test_pipeline_app.py
@@ -94,7 +94,7 @@ def test_no_opts():
     assert "export    Export a pipeline to a runtime-specific format" in result.output
     assert "validate  Validate pipeline" in result.output
 
-    assert result.exit_code == 0
+    assert result.exit_code == 2
 
 
 def test_bad_subcommand():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "autopep8>=1.5.0",
+    "click>=8.4.0",  
     "colorama",
     "deprecation",
     "entrypoints>=0.3",
@@ -29,7 +30,7 @@ dependencies = [
     "jupyterlab~=4.5.0",  # comment out to use local jupyterlab
     "jupyterlab-lsp~=5.1.0",  # comment out to use local jupyterlab
     "jupyterlab-git~=0.51.2",  # Avoid breaking 1.x changes
-    "jupyter-resource-usage~=1.2.1",
+    "jupyter-resource-usage~=1.1.0",
     "MarkupSafe>=2.1",
     "minio>=7.0.0,!=7.2.1",
     "nbclient>=0.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "autopep8>=1.5.0",
-    "click==8.1.8",  # elyra-ai/elyra#2579 -- 8.2.0 dropped support for Python 3.9
     "colorama",
     "deprecation",
     "entrypoints>=0.3",
@@ -30,7 +29,7 @@ dependencies = [
     "jupyterlab~=4.5.0",  # comment out to use local jupyterlab
     "jupyterlab-lsp~=5.1.0",  # comment out to use local jupyterlab
     "jupyterlab-git~=0.51.2",  # Avoid breaking 1.x changes
-    "jupyter-resource-usage~=1.1.0",
+    "jupyter-resource-usage~=1.2.1",
     "MarkupSafe>=2.1",
     "minio>=7.0.0,!=7.2.1",
     "nbclient>=0.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "jupyterlab~=4.5.0",  # comment out to use local jupyterlab
     "jupyterlab-lsp~=5.1.0",  # comment out to use local jupyterlab
     "jupyterlab-git~=0.51.2",  # Avoid breaking 1.x changes
-    "jupyter-resource-usage~=1.1.0",
+    "jupyter-resource-usage~=1.2.1",
     "MarkupSafe>=2.1",
     "minio>=7.0.0,!=7.2.1",
     "nbclient>=0.10.0",


### PR DESCRIPTION
Updating these two dependencies to avoid conflict with other packages on notebooks:

* `click` does not need to be pinned anymore because we don't support Python 3.9 anymore;
* `jupyter-resource-usage` is leading to dependency conflict with `psutil`


These dependencies change should solve the problems and unblock notebooks team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies: bumped jupyter-resource-usage to 1.2.1 and cleaned up explicit pin for click.
  * Environment setup now ensures pip is available when creating the runtime environment.

* **Tests**
  * CLI behavior when invoking the pipeline with no options now reflects a usage/error exit (test updated to expect this).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->