### PR TITLE
add agentic folder with skills for elyra image build and elyra release

### DIFF
--- a/.agents/skills/build-elyra-image-from-local.md
+++ b/.agents/skills/build-elyra-image-from-local.md
@@ -1,0 +1,111 @@
+---
+name: build-elyra-image-from-local
+description: Build and push a notebook image with local elyra changes for testing on RHOAI
+---
+
+# Build Elyra Image from Local Changes for RHOAI Testing
+
+Build a datascience notebook image that includes local elyra changes, push it to quay.io, and import it into RHOAI for testing.
+
+## Background
+
+The `odh-elyra` JupyterLab extension is developed in a separate repo (https://github.com/opendatahub-io/elyra) and packaged as a Python wheel. The notebooks repo (https://github.com/opendatahub-io/notebooks) builds the workbench container images that include `odh-elyra` as a dependency.
+
+The notebooks build system is hermetic — it uses prefetched wheels from a `cachi2/output/deps/pip/` directory with no network access during the container build. To test local elyra changes on RHOAI, we build a custom wheel, swap it into the prefetch cache, build the notebook image, and push it to quay.io for import into RHOAI. This workflow injects an unreleased wheel into the container build.
+
+## When to use
+
+- You have local elyra changes (your own branch, a coworker's PR branch, etc.) that you want to test on a deployed RHOAI or ODH instance
+- The changes may be on a branch that is behind elyra main or a release tag — that's fine, we rebase first
+
+## Repos involved
+
+- **Elyra repo:** https://github.com/opendatahub-io/elyra (upstream), plus your fork
+- **Notebooks repo:** https://github.com/opendatahub-io/notebooks (upstream), plus your fork
+- **Quay namespace for test images:** your quay.io namespace (e.g. `quay.io/<YOUR_USERNAME>/workbench-images`)
+
+## Steps
+
+### 1. In the elyra repo — build the wheel
+
+```bash
+# activate the venv first
+source .venv/bin/activate
+
+# checkout the branch with the local changes you want to test
+# if the branch is behind main or the latest release, rebase it:
+git fetch upstream --tags
+git rebase <LATEST_RELEASE_TAG>  # e.g. v5.0.2 — check `git tag --sort=-v:refname | head` for the latest
+```
+
+After rebasing, verify `elyra/_version.py` has the version matching the release tag you rebased onto. If it still shows a dev version (e.g. `5.0.0.dev0`), update it to match the release (e.g. `5.0.2`).
+
+```bash
+# build the wheel (includes frontend JS + backend)
+pip install -r build_requirements.txt
+make release
+# output: dist/odh_elyra-<VERSION>-py3-none-any.whl
+```
+
+`make release` requires Node.js and Yarn for the frontend build. If only backend changes are being tested and the frontend assets are already built, `python -m build` alone may suffice, but `make release` is the safe default.
+
+### 2. In the notebooks repo — prefetch dependencies and swap the wheel
+
+```bash
+# check out a new branch based on the latest main to make these changes
+# activate the venv
+uv sync
+source .venv/bin/activate
+
+# run the prefetch script to populate cachi2/output/deps/ with all build dependencies
+RELEASE_PYTHON_VERSION=3.12 BUILD_ARCH=linux/amd64 \
+    ./scripts/lockfile-generators/prefetch-all.sh \
+    --component-dir jupyter/datascience/ubi9-python-3.12
+```
+
+After the prefetch completes:
+
+1. **Copy your custom wheel** from `elyra/dist/odh_elyra-<VERSION>-py3-none-any.whl` into `notebooks/cachi2/output/deps/pip/`
+2. **Delete the old wheel** — remove the existing `odh_elyra-*-py3-none-any.whl` that the prefetch downloaded, so there's no ambiguity about which version gets installed
+3. **Update `requirements.cpu.txt`** — change the `odh-elyra==<OLD_VERSION>` line to match your wheel's version in `jupyter/datascience/ubi9-python-3.12/requirements.cpu.txt`. No hash updates are needed — the Dockerfile uses `--no-verify-hashes`
+
+**Note:** These instructions default to the datascience image (`jupyter/datascience/ubi9-python-3.12`). Tell the user you are updating the datascience image's requirements file. If they need to test on a different image (pytorch, tensorflow, trustyai, rocm), the corresponding `requirements.*.txt` file for that image must be updated instead. To find all files that pin elyra:
+
+```bash
+grep -rl "odh-elyra==" --include="requirements*.txt" .
+```
+
+### 3. Build the notebook image
+
+```bash
+make jupyter-datascience-ubi9-python-3.12 \
+    BUILD_ARCH=linux/amd64 \
+    PUSH_IMAGES=no
+```
+
+The Makefile auto-detects `cachi2/output/` and mounts it into the build. The output image will be tagged as `quay.io/opendatahub/workbench-images:jupyter-datascience-ubi9-python-3.12-<RELEASE>_<DATE>` — note the exact tag from the build output for the next step.
+
+### 4. Tag and push to quay.io
+
+```bash
+# retag with a descriptive name for your test
+podman tag <IMAGE_TAG_FROM_BUILD_OUTPUT> quay.io/<YOUR_NAMESPACE>/<YOUR_TEST_TAG>
+# e.g. quay.io/myuser/workbench-images:datascience-elyra-test
+
+podman login quay.io
+podman push quay.io/<YOUR_NAMESPACE>/<YOUR_TEST_TAG>
+```
+
+### 5. Import and test on RHOAI
+# This part should be done manually by the user to mimic customer usage, it should not be done by the model
+
+1. Go to **Settings > Notebook images > Import new image**
+2. Add `quay.io/<YOUR_NAMESPACE>/<YOUR_TEST_TAG>`
+3. Create a workbench using that image
+4. Test the elyra changes in the workbench
+
+## Troubleshooting
+
+- **Build fails with "No solution found" for a missing package:** The prefetch cache is incomplete. Run `prefetch-all.sh` again (step 2). After it completes, re-copy your custom elyra wheel and re-delete the old one before rebuilding.
+- **Wheel version mismatch:** Make sure the version in `requirements.cpu.txt` exactly matches the version string in your wheel filename (e.g. `odh_elyra-5.0.2-py3-none-any.whl` → `odh-elyra==5.0.2`).
+- **Rebase conflicts:** If rebasing the elyra branch onto a release tag produces conflicts, resolve them manually. If too many commits were already cherry-picked into the release, git will skip them automatically — this is expected and safe.

--- a/.agents/skills/build-elyra-image-from-local.md
+++ b/.agents/skills/build-elyra-image-from-local.md
@@ -22,7 +22,6 @@ It does **not** cover changes to `elyra/kfp/bootstrapper.py`. The bootstrapper r
 ## When to use
 
 - You have local elyra changes (your own branch, a coworker's PR branch, etc.) that you want to test on a deployed RHOAI or ODH instance
-- The changes may be on a branch that is behind elyra main or a release tag — that's fine, we rebase first
 
 ## Repos involved
 
@@ -39,19 +38,13 @@ It does **not** cover changes to `elyra/kfp/bootstrapper.py`. The bootstrapper r
 source .venv/bin/activate
 
 # checkout the branch with the local changes you want to test
-# if the branch is behind main or the latest release, rebase it:
-git fetch upstream --tags
-git rebase <LATEST_RELEASE_TAG>  # e.g. v5.0.2 — check `git tag --sort=-v:refname | head` for the latest
-```
-
-After rebasing, verify `elyra/_version.py` has the version matching the release tag you rebased onto. If it still shows a dev version (e.g. `5.0.0.dev0`), update it to match the release (e.g. `5.0.2`).
-
-```bash
 # build the wheel (includes frontend JS + backend)
 pip install -r build_requirements.txt
 make release
 # output: dist/odh_elyra-<VERSION>-py3-none-any.whl
 ```
+
+Note the version in the wheel filename (e.g. `5.0.0.dev0`) — you'll need it in step 2 to update `requirements.cpu.txt`.
 
 `make release` requires Node.js and Yarn for the frontend build. If only backend changes are being tested and the frontend assets are already built, `python -m build` alone may suffice, but `make release` is the safe default.
 
@@ -113,5 +106,4 @@ podman push quay.io/<YOUR_NAMESPACE>/<YOUR_TEST_TAG>
 ## Troubleshooting
 
 - **Build fails with "No solution found" for a missing package:** The prefetch cache is incomplete. Run `prefetch-all.sh` again (step 2). After it completes, re-copy your custom elyra wheel and re-delete the old one before rebuilding.
-- **Wheel version mismatch:** Make sure the version in `requirements.cpu.txt` exactly matches the version string in your wheel filename (e.g. `odh_elyra-5.0.2-py3-none-any.whl` → `odh-elyra==5.0.2`).
-- **Rebase conflicts:** If rebasing the elyra branch onto a release tag produces conflicts, resolve them manually. If too many commits were already cherry-picked into the release, git will skip them automatically — this is expected and safe.
+- **Wheel version mismatch:** Make sure the version in `requirements.cpu.txt` exactly matches the version string in your wheel filename (e.g. `odh_elyra-5.0.0.dev0-py3-none-any.whl` → `odh-elyra==5.0.0.dev0`).

--- a/.agents/skills/build-elyra-image-from-local.md
+++ b/.agents/skills/build-elyra-image-from-local.md
@@ -90,15 +90,18 @@ The Makefile auto-detects `cachi2/output/` and mounts it into the build. The out
 # retag with a descriptive name for your test
 podman tag <IMAGE_TAG_FROM_BUILD_OUTPUT> quay.io/<YOUR_NAMESPACE>/<YOUR_TEST_TAG>
 # e.g. quay.io/myuser/workbench-images:datascience-elyra-test
+```
 
-podman login quay.io
+Before pushing, the user must be logged in to quay.io. `podman login` requires interactive input and cannot be run by the agent. Ask the user to run `podman login quay.io` in their own terminal, then proceed with the push:
+
+```bash
 podman push quay.io/<YOUR_NAMESPACE>/<YOUR_TEST_TAG>
 ```
 
 ### 5. Import and test on RHOAI
 # This part should be done manually by the user to mimic customer usage, it should not be done by the model
 
-1. Go to **Settings > Notebook images > Import new image**
+1. Go to **Settings > Environment setup > Workbench images > Import new image**
 2. Add `quay.io/<YOUR_NAMESPACE>/<YOUR_TEST_TAG>`
 3. Create a workbench using that image
 4. Test the elyra changes in the workbench

--- a/.agents/skills/build-elyra-image-from-local.md
+++ b/.agents/skills/build-elyra-image-from-local.md
@@ -64,8 +64,8 @@ RELEASE_PYTHON_VERSION=3.12 BUILD_ARCH=linux/amd64 \
 
 After the prefetch completes:
 
-1. **Copy your custom wheel** from `elyra/dist/odh_elyra-<VERSION>-py3-none-any.whl` into `notebooks/cachi2/output/deps/pip/`
-2. **Delete the old wheel** — remove the existing `odh_elyra-*-py3-none-any.whl` that the prefetch downloaded, so there's no ambiguity about which version gets installed
+1. **Delete the old wheel** — remove the existing `odh_elyra-*-py3-none-any.whl` that the prefetch downloaded, so there's no ambiguity about which version gets installed
+2. **Copy your custom wheel** from `elyra/dist/odh_elyra-<VERSION>-py3-none-any.whl` into `notebooks/cachi2/output/deps/pip/`
 3. **Update `requirements.cpu.txt`** — change the `odh-elyra==<OLD_VERSION>` line to match your wheel's version in `jupyter/datascience/ubi9-python-3.12/requirements.cpu.txt`. No hash updates are needed — the Dockerfile uses `--no-verify-hashes`
 
 **Note:** These instructions default to the datascience image (`jupyter/datascience/ubi9-python-3.12`). Tell the user you are updating the datascience image's requirements file. If they need to test on a different image (pytorch, tensorflow, trustyai, rocm), the corresponding `requirements.*.txt` file for that image must be updated instead. To find all files that pin elyra:
@@ -105,5 +105,5 @@ podman push quay.io/<YOUR_NAMESPACE>/<YOUR_TEST_TAG>
 
 ## Troubleshooting
 
-- **Build fails with "No solution found" for a missing package:** The prefetch cache is incomplete. Run `prefetch-all.sh` again (step 2). After it completes, re-copy your custom elyra wheel and re-delete the old one before rebuilding.
+- **Build fails with "No solution found" for a missing package:** The prefetch cache is incomplete. Run `prefetch-all.sh` again (step 2). After it completes, re-delete the old elyra wheel and re-copy your custom one before rebuilding.
 - **Wheel version mismatch:** Make sure the version in `requirements.cpu.txt` exactly matches the version string in your wheel filename (e.g. `odh_elyra-5.0.0.dev0-py3-none-any.whl` → `odh-elyra==5.0.0.dev0`).

--- a/.agents/skills/build-elyra-image-from-local.md
+++ b/.agents/skills/build-elyra-image-from-local.md
@@ -13,6 +13,12 @@ The `odh-elyra` JupyterLab extension is developed in a separate repo (https://gi
 
 The notebooks build system is hermetic — it uses prefetched wheels from a `cachi2/output/deps/pip/` directory with no network access during the container build. To test local elyra changes on RHOAI, we build a custom wheel, swap it into the prefetch cache, build the notebook image, and push it to quay.io for import into RHOAI. This workflow injects an unreleased wheel into the container build.
 
+## Scope
+
+This skill builds a custom **workbench image** (`jupyter/datascience/`). It covers changes to the JupyterLab extension UI and the backend Python code that compiles and submits pipelines — everything that runs inside the user's browser/notebook session.
+
+It does **not** cover changes to `elyra/kfp/bootstrapper.py`. The bootstrapper runs inside **pipeline runtime images** (`runtimes/datascience/`), which are separate container images. The notebooks repo vendors a copy of the bootstrapper at `prefetch-input/elyra-v<VERSION>/elyra/kfp/bootstrapper.py` — that copy is baked into the runtime images independently of the workbench wheel. To test bootstrapper changes, you would need to also build a custom runtime image with the updated file.
+
 ## When to use
 
 - You have local elyra changes (your own branch, a coworker's PR branch, etc.) that you want to test on a deployed RHOAI or ODH instance

--- a/.agents/skills/elyra-release.md
+++ b/.agents/skills/elyra-release.md
@@ -75,6 +75,30 @@ You can also trigger this manually via `workflow_dispatch` with:
 
 The release workflow also runs daily at 4am UTC as a dry run (`release.yml` cron schedule). This catches build issues early without publishing anything. No action needed — just be aware it runs.
 
+## Post-release: update the vendored bootstrapper in the notebooks repo
+
+The `opendatahub-io/notebooks` repo vendors a copy of `elyra/kfp/bootstrapper.py` for use in **pipeline runtime images** — the containers that execute inside Kubeflow Pipeline steps. This copy is checked into the notebooks repo at `prefetch-input/elyra-v<VERSION>/elyra/kfp/bootstrapper.py` and is NOT updated automatically by the elyra release workflow. All seven runtime Dockerfiles (`runtimes/*/ubi9-python-3.12/Dockerfile.konflux.*`) COPY from this vendored path.
+
+After publishing a new elyra release, open a PR in the notebooks repo to update the bootstrapper:
+
+1. Replace `prefetch-input/elyra-v<OLD>/elyra/kfp/bootstrapper.py` with the file from the new tag:
+   ```bash
+   curl -o prefetch-input/elyra-v<OLD>/elyra/kfp/bootstrapper.py \
+     https://raw.githubusercontent.com/opendatahub-io/elyra/refs/tags/v<NEW>/elyra/kfp/bootstrapper.py
+   ```
+2. Rename the directory to match the new version:
+   ```bash
+   git mv prefetch-input/elyra-v<OLD> prefetch-input/elyra-v<NEW>
+   ```
+3. Update the README inside that directory to reflect the new version and upstream source URL.
+4. Update all runtime Dockerfiles that reference the old path. Find them with:
+   ```bash
+   grep -rl "elyra-v<OLD>" runtimes/
+   ```
+   Change `prefetch-input/elyra-v<OLD>/elyra/kfp/bootstrapper.py` to `prefetch-input/elyra-v<NEW>/elyra/kfp/bootstrapper.py` in each.
+
+If this step is skipped, pipeline runtime images will continue running the old bootstrapper even after the workbench images pick up the new elyra wheel via PyPI.
+
 ## Known gaps
 
 - How the git tag is created (manual vs automated)

--- a/.agents/skills/elyra-release.md
+++ b/.agents/skills/elyra-release.md
@@ -1,17 +1,16 @@
 ---
 name: elyra-release
-description: "DRAFT: Guide the user through the odh-elyra release process (some steps may be incomplete)"
+description: Guide the user through the odh-elyra release process
 ---
 
-# ODH-Elyra Release Process (DRAFT)
-
-**This skill is a draft.** It documents what is known about the release process from the repo's CI workflows and scripts. Steps marked with "UNKNOWN" need to be filled in by someone who has done a release before.
+# ODH-Elyra Release Process
 
 ## Prerequisites
 
 - Write access to the `opendatahub-io/elyra` repo
 - Permissions to trigger GitHub Actions workflows
 - PyPI trusted publishing is configured (no manual credentials needed)
+- `gh` CLI authenticated
 
 ## Steps
 
@@ -19,89 +18,90 @@ description: "DRAFT: Guide the user through the odh-elyra release process (some 
 
 Determine the new version (e.g. `5.0.3`). Follow semver conventions — patch for bug fixes, minor for new features, major for breaking changes.
 
-### 2. Update the version via GitHub Actions
+### 2. Create the release branch (major/minor only)
 
-Trigger the **"Update version through Pull Request"** workflow (`update-version-through-pr.yml`) in the GitHub Actions UI:
+If this is a **patch release** (e.g. `5.0.2` → `5.0.3`), skip this step — the existing release branch (e.g. `v5.0.x`) is reused.
 
-- **version**: the new version (e.g. `5.0.3`)
-- **source_branch**: the branch to update (usually `main`)
-- **target_branch**: the branch to merge into (usually a release branch)
+If this is a **minor version increase** (e.g. `5.0.x` → `5.1.x`), create the new release branch from the previous release branch:
 
-This runs `.github/workflows/scripts/update_version.sh`, which updates the version in:
-- `elyra/_version.py`
-- Root `package.json`
-- All lerna sub-package `package.json` files
+```bash
+git checkout v5.0.x && git pull upstream v5.0.x
+git checkout -b v5.1.x
+git push upstream v5.1.x
+```
 
-It then opens a PR automatically.
+If this is a **major version increase** (e.g. `5.0.x` → `6.0.x`), create the new release branch from `main`:
 
-### 3. Review and merge the version bump PR
+```bash
+git checkout main && git pull upstream main
+git checkout -b v6.0.x
+git push upstream v6.0.x
+```
+
+### 3. Cherry-pick fixes onto the release branch
+
+Go to the release branch (e.g. `v5.0.x`) and cherry-pick all the features and fixes intended for this release. This is a human judgment step — decide which commits from `main` belong in the release.
+
+### 4. Trigger the version bump workflow
+
+From the elyra repo, run:
+
+```bash
+python scripts/release/trigger_version_bump.py <VERSION> --source-branch <RELEASE_BRANCH> --target-branch <RELEASE_BRANCH>
+```
+
+This triggers the `update-version-through-pr.yml` workflow, which updates the version across all 15 files (`elyra/_version.py`, root `package.json`, `lerna.json`, and 12 sub-package `package.json` files) and opens a PR automatically.
+
+The version bump commit must be the last commit before the release tag.
+
+### 5. Review and merge the version bump PR
 
 Review the automated PR to confirm the version was updated correctly across all files, then merge it.
 
-### 4. Tag the release
+### 6. Create the GitHub release
 
-**UNKNOWN**: It is not clear from the repo whether the tag is created manually or automatically after the version PR merges. Someone needs to create a git tag matching the version:
+From the elyra repo, run:
 
 ```bash
-git tag v5.0.3
-git push origin v5.0.3
+python scripts/release/create_release.py <VERSION> --target-branch <RELEASE_BRANCH>
 ```
 
-### 5. Publish to PyPI (automatic)
+This creates a GitHub release with auto-generated release notes and a `v<VERSION>` tag pointing at the release branch. The `v*` tag push automatically triggers the `release.yml` workflow, which builds the wheel and publishes to PyPI via trusted publishing.
 
-Pushing the `v*` tag triggers the **"Elyra Release"** workflow (`release.yml`), which:
-1. Checks out the tagged commit
-2. Verifies `_version.py` matches the tag
-3. Builds the wheel (`make install-prod`)
-4. Publishes to PyPI via trusted publishing
+### 7. Verify PyPI publish
 
-You can also trigger this manually via `workflow_dispatch` with:
-- **tag**: the tag name (e.g. `v5.0.3`)
-- **dry_run**: set to `true` to test without publishing
+```bash
+python scripts/release/verify_pypi_publish.py <VERSION>
+```
 
-### 6. Create a GitHub Release
+This polls PyPI until `odh-elyra` at the given version appears (default timeout: 300s).
 
-**UNKNOWN**: It is not clear whether a GitHub Release is created manually or by another workflow. Check the repo's release history for conventions on release notes format.
+### 8. Update the vendored bootstrapper in the notebooks repo
 
-### 7. Container image
+The `opendatahub-io/notebooks` repo vendors a copy of `elyra/kfp/bootstrapper.py` for use in **pipeline runtime images** — the containers that execute inside Kubeflow Pipeline steps. This copy is checked into the notebooks repo at `prefetch-input/elyra-v<VERSION>/elyra/kfp/bootstrapper.py` and is NOT updated automatically by the elyra release workflow. All seven runtime Dockerfiles (`runtimes/*/ubi9-python-3.12/Dockerfile.konflux.*`) COPY from this vendored path.
 
-**UNKNOWN**: The release workflow only publishes to PyPI. It is not clear how or where container images are built and published for releases. This may happen in a separate CI system or be a manual step.
+This script automates the file changes in a local clone of the notebooks repo. It downloads the new bootstrapper from the release tag, updates the README, renames the `prefetch-input/elyra-v*` directory, and patches all runtime Dockerfiles:
 
-### 8. Post-release: bump main to dev version
+```bash
+python scripts/release/update_notebooks_bootstrapper.py <VERSION> /path/to/local/notebooks/repo
+```
 
-**UNKNOWN**: After a release, main should be bumped to the next dev version (e.g. `5.1.0.dev0`). It is not clear if this is done automatically or manually. Currently, main shows `5.0.0.dev0` even after multiple 5.x releases, which may be an oversight.
+After running it, review the changes in the notebooks repo, commit them, and open a PR there.
+
+If this step is skipped, pipeline runtime images will continue running the old bootstrapper even after the workbench images pick up the new elyra wheel via PyPI.
+
+### 9. (Optional) Bump to next dev version
+
+```bash
+python scripts/release/trigger_version_bump.py <NEXT_DEV_VERSION> --source-branch <RELEASE_BRANCH> --target-branch main
+```
+
+For example, after releasing `5.0.3`, bump to `5.1.0.dev0`. This opens a PR against `main`. Review and merge it.
 
 ## Daily CI dry run
 
 The release workflow also runs daily at 4am UTC as a dry run (`release.yml` cron schedule). This catches build issues early without publishing anything. No action needed — just be aware it runs.
 
-## Post-release: update the vendored bootstrapper in the notebooks repo
+## Container images
 
-The `opendatahub-io/notebooks` repo vendors a copy of `elyra/kfp/bootstrapper.py` for use in **pipeline runtime images** — the containers that execute inside Kubeflow Pipeline steps. This copy is checked into the notebooks repo at `prefetch-input/elyra-v<VERSION>/elyra/kfp/bootstrapper.py` and is NOT updated automatically by the elyra release workflow. All seven runtime Dockerfiles (`runtimes/*/ubi9-python-3.12/Dockerfile.konflux.*`) COPY from this vendored path.
-
-After publishing a new elyra release, open a PR in the notebooks repo to update the bootstrapper:
-
-1. Replace `prefetch-input/elyra-v<OLD>/elyra/kfp/bootstrapper.py` with the file from the new tag:
-   ```bash
-   curl -o prefetch-input/elyra-v<OLD>/elyra/kfp/bootstrapper.py \
-     https://raw.githubusercontent.com/opendatahub-io/elyra/refs/tags/v<NEW>/elyra/kfp/bootstrapper.py
-   ```
-2. Rename the directory to match the new version:
-   ```bash
-   git mv prefetch-input/elyra-v<OLD> prefetch-input/elyra-v<NEW>
-   ```
-3. Update the README inside that directory to reflect the new version and upstream source URL.
-4. Update all runtime Dockerfiles that reference the old path. Find them with:
-   ```bash
-   grep -rl "elyra-v<OLD>" runtimes/
-   ```
-   Change `prefetch-input/elyra-v<OLD>/elyra/kfp/bootstrapper.py` to `prefetch-input/elyra-v<NEW>/elyra/kfp/bootstrapper.py` in each.
-
-If this step is skipped, pipeline runtime images will continue running the old bootstrapper even after the workbench images pick up the new elyra wheel via PyPI.
-
-## Known gaps
-
-- How the git tag is created (manual vs automated)
-- How GitHub Releases are created and what format the release notes follow
-- How container images are built and published for releases
-- Whether main's dev version is supposed to be bumped after each release
+Container images are not part of the elyra release process. The `notebooks` repo builds workbench and pipeline runtime images separately. The elyra release only publishes to PyPI.

--- a/.agents/skills/elyra-release.md
+++ b/.agents/skills/elyra-release.md
@@ -1,0 +1,83 @@
+---
+name: elyra-release
+description: "DRAFT: Guide the user through the odh-elyra release process (some steps may be incomplete)"
+---
+
+# ODH-Elyra Release Process (DRAFT)
+
+**This skill is a draft.** It documents what is known about the release process from the repo's CI workflows and scripts. Steps marked with "UNKNOWN" need to be filled in by someone who has done a release before.
+
+## Prerequisites
+
+- Write access to the `opendatahub-io/elyra` repo
+- Permissions to trigger GitHub Actions workflows
+- PyPI trusted publishing is configured (no manual credentials needed)
+
+## Steps
+
+### 1. Decide the new version number
+
+Determine the new version (e.g. `5.0.3`). Follow semver conventions — patch for bug fixes, minor for new features, major for breaking changes.
+
+### 2. Update the version via GitHub Actions
+
+Trigger the **"Update version through Pull Request"** workflow (`update-version-through-pr.yml`) in the GitHub Actions UI:
+
+- **version**: the new version (e.g. `5.0.3`)
+- **source_branch**: the branch to update (usually `main`)
+- **target_branch**: the branch to merge into (usually a release branch)
+
+This runs `.github/workflows/scripts/update_version.sh`, which updates the version in:
+- `elyra/_version.py`
+- Root `package.json`
+- All lerna sub-package `package.json` files
+
+It then opens a PR automatically.
+
+### 3. Review and merge the version bump PR
+
+Review the automated PR to confirm the version was updated correctly across all files, then merge it.
+
+### 4. Tag the release
+
+**UNKNOWN**: It is not clear from the repo whether the tag is created manually or automatically after the version PR merges. Someone needs to create a git tag matching the version:
+
+```bash
+git tag v5.0.3
+git push origin v5.0.3
+```
+
+### 5. Publish to PyPI (automatic)
+
+Pushing the `v*` tag triggers the **"Elyra Release"** workflow (`release.yml`), which:
+1. Checks out the tagged commit
+2. Verifies `_version.py` matches the tag
+3. Builds the wheel (`make install-prod`)
+4. Publishes to PyPI via trusted publishing
+
+You can also trigger this manually via `workflow_dispatch` with:
+- **tag**: the tag name (e.g. `v5.0.3`)
+- **dry_run**: set to `true` to test without publishing
+
+### 6. Create a GitHub Release
+
+**UNKNOWN**: It is not clear whether a GitHub Release is created manually or by another workflow. Check the repo's release history for conventions on release notes format.
+
+### 7. Container image
+
+**UNKNOWN**: The release workflow only publishes to PyPI. It is not clear how or where container images are built and published for releases. This may happen in a separate CI system or be a manual step.
+
+### 8. Post-release: bump main to dev version
+
+**UNKNOWN**: After a release, main should be bumped to the next dev version (e.g. `5.1.0.dev0`). It is not clear if this is done automatically or manually. Currently, main shows `5.0.0.dev0` even after multiple 5.x releases, which may be an oversight.
+
+## Daily CI dry run
+
+The release workflow also runs daily at 4am UTC as a dry run (`release.yml` cron schedule). This catches build issues early without publishing anything. No action needed — just be aware it runs.
+
+## Known gaps
+
+- How the git tag is created (manual vs automated)
+- How GitHub Releases are created and what format the release notes follow
+- How container images are built and published for releases
+- Whether main's dev version is supposed to be bumped after each release

--- a/.agents/skills/elyra-release.md
+++ b/.agents/skills/elyra-release.md
@@ -90,17 +90,9 @@ After running it, review the changes in the notebooks repo, commit them, and ope
 
 If this step is skipped, pipeline runtime images will continue running the old bootstrapper even after the workbench images pick up the new elyra wheel via PyPI.
 
-### 9. (Optional) Bump to next dev version
-
-```bash
-python scripts/release/trigger_version_bump.py <NEXT_DEV_VERSION> --source-branch <RELEASE_BRANCH> --target-branch main
-```
-
-For example, after releasing `5.0.3`, bump to `5.1.0.dev0`. This opens a PR against `main`. Review and merge it.
-
 ## Daily CI dry run
 
-The release workflow also runs daily at 4am UTC as a dry run (`release.yml` cron schedule). This catches build issues early without publishing anything. No action needed — just be aware it runs.
+The release workflow also runs daily at 4am UTC as a dry run (`release.yml` cron schedule).
 
 ## Container images
 

--- a/scripts/release/create_release.py
+++ b/scripts/release/create_release.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Create a GitHub release, which creates the v* tag and triggers PyPI publish."""
+
 import argparse
 import subprocess
 
@@ -12,10 +13,15 @@ def main():
 
     tag = f"v{args.version}"
     cmd = [
-        "gh", "release", "create", tag,
-        "--target", args.target_branch,
+        "gh",
+        "release",
+        "create",
+        tag,
+        "--target",
+        args.target_branch,
         "--generate-notes",
-        "--title", tag,
+        "--title",
+        tag,
     ]
     print(f"Running: {' '.join(cmd)}")
     result = subprocess.run(cmd, check=True, capture_output=True, text=True)

--- a/scripts/release/create_release.py
+++ b/scripts/release/create_release.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Create a GitHub release, which creates the v* tag and triggers PyPI publish."""
+import argparse
+import subprocess
+
+
+def main():
+    p = argparse.ArgumentParser(description="Create a GitHub release")
+    p.add_argument("version", help="Version to release, e.g. 5.0.3")
+    p.add_argument("--target-branch", required=True, help="Release branch, e.g. v5.0.x")
+    args = p.parse_args()
+
+    tag = f"v{args.version}"
+    cmd = [
+        "gh", "release", "create", tag,
+        "--target", args.target_branch,
+        "--generate-notes",
+        "--title", tag,
+    ]
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    print(f"Release created: {result.stdout.strip()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/trigger_version_bump.py
+++ b/scripts/release/trigger_version_bump.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Trigger the update-version-through-pr workflow to create a version bump PR."""
+
 import argparse
 import subprocess
 
@@ -12,10 +13,16 @@ def main():
     args = p.parse_args()
 
     cmd = [
-        "gh", "workflow", "run", "update-version-through-pr.yml",
-        "-f", f"version={args.version}",
-        "-f", f"source_branch={args.source_branch}",
-        "-f", f"target_branch={args.target_branch}",
+        "gh",
+        "workflow",
+        "run",
+        "update-version-through-pr.yml",
+        "-f",
+        f"version={args.version}",
+        "-f",
+        f"source_branch={args.source_branch}",
+        "-f",
+        f"target_branch={args.target_branch}",
     ]
     print(f"Running: {' '.join(cmd)}")
     subprocess.run(cmd, check=True)

--- a/scripts/release/trigger_version_bump.py
+++ b/scripts/release/trigger_version_bump.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Trigger the update-version-through-pr workflow to create a version bump PR."""
+import argparse
+import subprocess
+
+
+def main():
+    p = argparse.ArgumentParser(description="Trigger version bump PR workflow")
+    p.add_argument("version", help="New version, e.g. 5.0.3")
+    p.add_argument("--source-branch", required=True, help="Branch to update, e.g. v5.0.x")
+    p.add_argument("--target-branch", required=True, help="PR target branch, e.g. v5.0.x")
+    args = p.parse_args()
+
+    cmd = [
+        "gh", "workflow", "run", "update-version-through-pr.yml",
+        "-f", f"version={args.version}",
+        "-f", f"source_branch={args.source_branch}",
+        "-f", f"target_branch={args.target_branch}",
+    ]
+    print(f"Running: {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+    print(f"Workflow triggered for version {args.version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/update_notebooks_bootstrapper.py
+++ b/scripts/release/update_notebooks_bootstrapper.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Update vendored bootstrapper.py in the notebooks repo after an elyra release."""
+
 import argparse
 import subprocess
 import sys
@@ -43,8 +44,7 @@ def main():
 
     new_dir = prefetch / new_name
     subprocess.run(
-        ["git", "-C", str(repo), "mv",
-         str(old_dir.relative_to(repo)), str(new_dir.relative_to(repo))],
+        ["git", "-C", str(repo), "mv", str(old_dir.relative_to(repo)), str(new_dir.relative_to(repo))],
         check=True,
     )
     print(f"  Renamed {old_name} -> {new_name}")

--- a/scripts/release/update_notebooks_bootstrapper.py
+++ b/scripts/release/update_notebooks_bootstrapper.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Update vendored bootstrapper.py in the notebooks repo after an elyra release."""
+import argparse
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+
+def main():
+    p = argparse.ArgumentParser(description="Update vendored elyra bootstrapper in notebooks repo")
+    p.add_argument("version", help="New elyra version, e.g. 5.0.3")
+    p.add_argument("notebooks_repo", help="Path to notebooks repo checkout")
+    args = p.parse_args()
+
+    repo = Path(args.notebooks_repo)
+    tag = f"v{args.version}"
+    prefetch = repo / "prefetch-input"
+
+    matches = sorted(prefetch.glob("elyra-v*"))
+    if len(matches) != 1:
+        print(f"Expected 1 elyra-v* dir in {prefetch}, found {len(matches)}: {matches}", file=sys.stderr)
+        sys.exit(1)
+    old_dir = matches[0]
+    old_name = old_dir.name
+    new_name = f"elyra-{tag}"
+
+    if old_name == new_name:
+        print(f"Already at {new_name}, nothing to do")
+        sys.exit(1)
+
+    url = f"https://raw.githubusercontent.com/opendatahub-io/elyra/refs/tags/{tag}/elyra/kfp/bootstrapper.py"
+    print(f"Downloading {url}")
+    content = urllib.request.urlopen(url).read()
+    bp = old_dir / "elyra" / "kfp" / "bootstrapper.py"
+    bp.write_bytes(content)
+    print(f"  Updated {bp.relative_to(repo)}")
+
+    readme = old_dir / "elyra" / "kfp" / "README.md"
+    old_tag = old_name.removeprefix("elyra-")
+    readme.write_text(readme.read_text().replace(old_tag, tag))
+    print(f"  Updated {readme.relative_to(repo)}")
+
+    new_dir = prefetch / new_name
+    subprocess.run(
+        ["git", "-C", str(repo), "mv",
+         str(old_dir.relative_to(repo)), str(new_dir.relative_to(repo))],
+        check=True,
+    )
+    print(f"  Renamed {old_name} -> {new_name}")
+
+    count = 0
+    for dockerfile in (repo / "runtimes").rglob("Dockerfile.konflux.*"):
+        text = dockerfile.read_text()
+        if old_name in text:
+            dockerfile.write_text(text.replace(old_name, new_name))
+            count += 1
+            print(f"  Updated {dockerfile.relative_to(repo)}")
+
+    print(f"\nDone. Updated bootstrapper, README, renamed dir, patched {count} Dockerfiles.")
+    print(f"Review changes with: git -C {repo} diff --stat")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/verify_pypi_publish.py
+++ b/scripts/release/verify_pypi_publish.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Poll PyPI until the odh-elyra package at a given version is published."""
+import argparse
+import sys
+import time
+import urllib.error
+import urllib.request
+
+PACKAGE = "odh-elyra"
+POLL_INTERVAL = 30
+
+
+def main():
+    p = argparse.ArgumentParser(description="Verify PyPI publish of odh-elyra")
+    p.add_argument("version", help="Version to check, e.g. 5.0.3")
+    p.add_argument("--timeout", type=int, default=300, help="Timeout in seconds (default: 300)")
+    args = p.parse_args()
+
+    url = f"https://pypi.org/pypi/{PACKAGE}/{args.version}/json"
+    deadline = time.time() + args.timeout
+    print(f"Polling {url} (timeout {args.timeout}s)")
+
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(url)
+            print(f"{PACKAGE} {args.version} is on PyPI")
+            return
+        except urllib.error.HTTPError:
+            remaining = int(deadline - time.time())
+            print(f"  Not yet available, {remaining}s remaining...")
+            time.sleep(POLL_INTERVAL)
+
+    print(f"TIMEOUT: {PACKAGE} {args.version} not found after {args.timeout}s", file=sys.stderr)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/verify_pypi_publish.py
+++ b/scripts/release/verify_pypi_publish.py
@@ -22,14 +22,14 @@ def main():
     print(f"Polling {url} (timeout {args.timeout}s)")
 
     while time.time() < deadline:
+        remaining = deadline - time.time()
         try:
-            urllib.request.urlopen(url)
+            urllib.request.urlopen(url, timeout=min(POLL_INTERVAL, remaining))
             print(f"{PACKAGE} {args.version} is on PyPI")
             return
         except urllib.error.HTTPError:
-            remaining = int(deadline - time.time())
-            print(f"  Not yet available, {remaining}s remaining...")
-            time.sleep(POLL_INTERVAL)
+            print(f"  Not yet available, {int(remaining)}s remaining...")
+            time.sleep(min(POLL_INTERVAL, remaining))
 
     print(f"TIMEOUT: {PACKAGE} {args.version} not found after {args.timeout}s", file=sys.stderr)
     sys.exit(1)

--- a/scripts/release/verify_pypi_publish.py
+++ b/scripts/release/verify_pypi_publish.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Poll PyPI until the odh-elyra package at a given version is published."""
+
 import argparse
 import sys
 import time


### PR DESCRIPTION
This PR adds the `.agents/skills` directory to elyra.
 

It also adds two skills:
- `build-elyra-image-from-local.md` - This skill allows us to build a RHOAI notebook image using local elyra changes, which allows the team to deploy images and test them on RHOAI before merging any changes to the repo.
- `elyra-release.md` - This skill is a DRAFT. I would like to get review feedback on it so that we can better automate the elyra release workflow. @jesuino @adrielparedes @caponetto 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command-line tools to automate release creation, version updates, and publication verification.
  * Added tooling to update the notebooks bootstrapper for a selected Elyra release.

* **Documentation**
  * Added guidance for building and testing notebook images from local Elyra changes.
  * Documented the Elyra release process, including versioning, publishing, container images, and post-release steps.
  * Included troubleshooting advice, prerequisites, and notes on known release-process boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->